### PR TITLE
See: WhatsNew.md

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -3,23 +3,24 @@ $ModuleRoot = Get-Item $PSScriptRoot\..
 $SourceFolder = Join-Path $ModuleRoot 'Source'
 
 $PSModule  = [Collections.Generic.List[String]]::new()
-
+$ToProcess = [Collections.Generic.List[String]]::new()
 $Functions = [Collections.Generic.List[String]]::new()
+$Aliases   = [Collections.Generic.List[String]]::new()
+
 Get-ChildItem -Path $SourceFolder\Private -Filter *.ps1 | Foreach-Object {
     . $_.FullName
     $TrailingPath = $_.FullName.SubString($ModuleRoot.FullName.Length)
     $PSModule.Add(". `$PSScriptRoot$TrailingPath")
+    $ToProcess.Add(".$TrailingPath")
 }
 
-$Classes = [Collections.Generic.List[String]]::new()
 Get-ChildItem -Path $SourceFolder\Classes -Filter *.ps1 | Foreach-Object {
     . $_.FullName
     $TrailingPath = $_.FullName.SubString($ModuleRoot.FullName.Length)
     $PSModule.Add(". `$PSScriptRoot$TrailingPath")
-    $Classes.Add(".$TrailingPath")
+    $ToProcess.Add(".$TrailingPath")
 }
 
-$Aliases = [Collections.Generic.List[String]]::new()
 Get-ChildItem -Path $SourceFolder\Public -Filter *.ps1 | Foreach-Object {
     . $_.FullName
     $TrailingPath = $_.FullName.SubString($ModuleRoot.FullName.Length)
@@ -72,9 +73,9 @@ elseif ($PSD1.ModuleVersion -le $PSGalleryModule.Version) {
     if (-not $UpdatePSD1) { $UpdatePSD1 = Get-Content -Raw $ModuleRoot\ObjectGraphTools.psd1 }
     $UpdatePSD1 = UpdateSetting $UpdatePSD1 'ModuleVersion' "'$Version'"
 }
-if (Compare-Object $Classes $PSD1.ScriptsToProcess) {
+if (Compare-Object $ToProcess $PSD1.ScriptsToProcess) {
     if (-not $UpdatePSD1) { $UpdatePSD1 = Get-Content -Raw -LiteralPath $ModuleRoot\ObjectGraphTools.psd1 }
-    $UpdatePSD1 = UpdateSetting $UpdatePSD1 'ScriptsToProcess' "@($(@($Classes).foreach{ "'$_'" } -Join ', '))"
+    $UpdatePSD1 = UpdateSetting $UpdatePSD1 'ScriptsToProcess' "@($(@($ToProcess).foreach{ "'$_'" } -Join ', '))"
 }
 if (Compare-Object $Functions $PSD1.FunctionsToExport) {
     if (-not $UpdatePSD1) { $UpdatePSD1 = Get-Content -Raw -LiteralPath $ModuleRoot\ObjectGraphTools.psd1 }

--- a/Docs/ObjectParser.md
+++ b/Docs/ObjectParser.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD033 -->
+# Object Parser
+
 This class provides general properties and method to recursively
 iterate through to PowerShell Object Graph nodes.
 
@@ -7,17 +10,17 @@ The following function recursively iterates through all the property nodes (`PSN
 of an object-graph and returns the path to each object.
 
 ```PowerShell
-    function Iterate([PSNode]$Node) { # Basic iterator
-        $Node.PathName
-        if ($Node -is [PSCollectionNode]) {
-            $Node.ChildNodes.foreach{ Iterate $_ }
-        }
+function Iterate([PSNode]$Node) { # Basic iterator
+    $Node.PathName
+    if ($Node -is [PSCollectionNode]) {
+        $Node.ChildNodes.foreach{ Iterate $_ }
     }
+}
 
-    $Object = $Json | ConvertFrom-Json
-    $PSNode = [PSNode]::ParseInput($Object)
-    Iterate $PSNode
-``````
+$Object = $Json | ConvertFrom-Json
+$PSNode = [PSNode]::ParseInput($Object)
+Iterate $PSNode
+```
 
 ## Class hierarchy
 
@@ -97,6 +100,12 @@ The value might be modified but should be of the same structure (`[PSLeafNode]`,
 The depth where the current PSNode resides in the PSNode hierarchy (aka tree).
 An error will occur if the depth exceed the `MaxDepth` setting.
 
+### `MaxDepth`
+
+The maximum iteration depth of the embedded graph object.
+The `MaxDepth` value can be read at every level but can only be set on the root node:
+`[PSNode].RootNode.MaxDepth = <Maximum Depth>`
+
 ### `ValueType` (ReadOnly)
 
 The type of the value embedded by the PSNode.
@@ -115,27 +124,29 @@ Refers to node containing the current PSNode and possible siblings.
 
 Refers to the top node containing the current PSNode and all its decedents.
 
-### `ChildNodes` (ReadOnly)
+### `ChildNodes` (ReadOnly) (`[PSCollectionNodes]` only)
 
-(`[PSCollectionNodes]` only)
 Returns all the child nodes contained by the current PSNode.
 To retrieve a specific child node, use the `GetChildNode(<Name>)` method.
 
-### `Count` (ReadOnly)
+### `DescendantNodes` (ReadOnly) (`[PSCollectionNodes]` only)
 
-(`[PSCollectionNodes]` only)
+Returns all the descendant nodes (up and till the `$MaxDepth` level) contained
+by the current PSNode.
+
+### `Count` (ReadOnly) (`[PSCollectionNodes]` only)
+
 Returns the number of items or properties contained by the embedded value.
 This number is equal to the number of child nodes contained by the current node.
 
-### `Names` (ReadOnly)
+### `Names` (ReadOnly) (`[PSCollectionNodes]` only)
 
-(`[PSCollectionNodes]` only)
 Returns the property or key names of the embedded value. If the PSNode is of
 `[PSListNode]` type list a indices (starting from zero) is returned.
 The name of each child node is equal to the name (or index) that identifies item
 of the embedded value
 
-### `Values` (ReadOnly)
+### `Values` (ReadOnly) (`[PSCollectionNodes]` only)
 
 Returns all the value of the items or properties of the embedded value.
 A PSNode derived from a `[PSLeafNode]` type doesn't have a `Values` property.
@@ -162,26 +173,46 @@ The `<maximal depth>` argument, set the maximal depth of the properties  that wi
 recursively retrieve. When the maximal depth is reached, an error is throw.
 The default maximal depth is defined by the static property `[PSNode]::MaxDepth` (default: 10)
 
-### `GetChildNode(<name>)`
+### `GetChildNode(<name>)` (`[PSCollectionNodes]` only)
 
-(`[PSCollectionNodes]` only)
 Returns a specific child node (`[PSNode]`) selected by the name (or index) of the embedded
 
-### `GetItem(<name>)`
+> [!Note]
+> The `GetChildNode` has a Shorthand ("alias"): `_(<name>)` which shouldn't be used
+> in scripts as the its name or functionality might change in the future
 
-(`[PSCollectionNodes]` only)
+### `GetDescendentNode(<path>)` (`[PSCollectionNodes]` only)
+
+Returns a specific child node (`[PSNode]`) selected by the path of the embedded object
+The path might be either:
+
+* As [String] a "dot-property" selection as defined by the `PathName` property a specific node.
+* A array of strings (dictionary keys or Property names) and/or Integers (list indices).
+* A object (`PSNode[]`) list where each `Name` property defines the path
+
+> [!Note]
+> The `GetDescendentNode` has a Shorthand ("alias"): `Get(<name>)` which shouldn't be used
+> in scripts as the its name or functionality might change in the future
+
+### `GetDescendentNodes(<generations>)` (`[PSCollectionNodes]` only)
+
+Returns all descendant nodes of the current node for a the defined number of generations.
+
+> [!Note]
+> The number of generations will not surpass the `MaxDepth` defined at the root.
+
+### `GetItem(<name>)` (`[PSCollectionNodes]` only)
+
 Returns the value of a specific item identified by `<name>` of the embedded collection
 or object.
 
-### `SetItem(<name>, <value>)`
+### `SetItem(<name>, <value>)` (`[PSCollectionNodes]` only)
 
-(`[PSCollectionNodes]` only)
 Sets the value of a specific item identified by `<name>` of the embedded collection
 or object. The new value should be of the same structure (`[PSLeafNode]`, `[PSListNode]`,
 `[PSDictionaryNode]` or `[PSObjectNode]`) as the original node type.
 
-### `Contains(<name>)`
+### `Contains(<name>)` (`[PSCollectionNodes]` only)
 
-(`[PSCollectionNodes]` only)
 Determines whether a specific item identified by `<name>` is contained by th embedded
 collection or object.

--- a/ObjectGraphTools.psd1
+++ b/ObjectGraphTools.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ObjectGraphTools.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.0.11'
+    ModuleVersion = '0.0.12'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/ObjectGraphTools.psd1
+++ b/ObjectGraphTools.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ObjectGraphTools.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.0.10'
+    ModuleVersion = '0.0.11'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -48,7 +48,7 @@
     # RequiredAssemblies = @()
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-    ScriptsToProcess = @('.\Source\Classes\ObjectParser.ps1')
+    ScriptsToProcess = @('.\Source\Private\Use-ClassAccessors.ps1', '.\Source\Classes\ObjectParser.ps1')
 
     # Type files (.ps1xml) to be loaded when importing this module
     # TypesToProcess = @()
@@ -120,6 +120,7 @@
     # DefaultCommandPrefix = ''
 
 }
+
 
 
 

--- a/Source/Classes/ObjectParser.ps1
+++ b/Source/Classes/ObjectParser.ps1
@@ -1,194 +1,224 @@
 <#
-.SYNOPSIS
-    PowerShell Object Node Class
+# Object Parser
 
-.DESCRIPTION
-    This class provides general properties and method to recursively
-    iterate through to PowerShell Object Graph nodes.
+This class provides general properties and method to recursively
+iterate through to PowerShell Object Graph nodes.
 
-    ## Example
+## Example "Iterate trough each recursive node and return it property path"
 
-        # Iterate trough each recursive node and return it property path
+The following function recursively iterates through all the property nodes (`PSNodes`)
+of an object-graph and returns the path to each object.
 
-    The following function recursively iterates through all the property nodes (`PSNodes`)
-    of an object-graph and returns the path to each object.
+```PowerShell
+function Iterate([PSNode]$Node) { # Basic iterator
+    $Node.PathName
+    if ($Node -is [PSCollectionNode]) {
+        $Node.ChildNodes.foreach{ Iterate $_ }
+    }
+}
 
-        function Iterate([PSNode]$Node) { # Basic iterator
-            $Node.PathName
-            if ($Node -is [PSCollectionNode]) {
-                $Node.ChildNodes.foreach{ Iterate $_ }
-            }
-        }
+$Object = $Json | ConvertFrom-Json
+$PSNode = [PSNode]::ParseInput($Object)
+Iterate $PSNode
+```
 
-        $Object = $Json | ConvertFrom-Json
-        $PSNode = [PSNode]::ParseInput($Object)
-        Iterate $PSNode
+## Class hierarchy
 
-    ## Class hierarchy
+The general class is called `[PSNode]`and has a hierarchy of sub-classes
 
-    The general class is called `[PSNode]`and has a hierarchy of sub-classes
+```plaintext
+         [PSLeafNode]
+        /
+[PSNode]                    [PSListNode]
+        \                  /
+         [PSCollectionNode]             [PSDictionaryNode]
+                           \           /
+                            [PSMapNode]
+                                       \
+                                        [PSObjectNode]
+```
 
-                 [PSLeafNode]
-                /
-        [PSNode]                    [PSListNode]
-                \                  /
-                 [PSCollectionNode]             [PSDictionaryNode]
-                                   \           /
-                                    [PSMapNode]
-                                               \
-                                                [PSObjectNode]
+### `[PSNode]`
 
-    ### `[PSNode]`
+The base type of a PSNode. Each PSNode will have at least 1 additional PSNode derivative
+listed below.
 
-    The base type of a PSNode. Each PSNode will have at least 1 additional PSNode derivative
-    listed below.
+### `[PSLeafNode]`
 
-    ### `[PSLeafNode]`
+A PSLeafNode terminates a PSNode branch and doesn't have any child nodes attached.
+A value embedded by a PSLeafNode is not enumerable and doesn't contain any object properties.
 
-    A PSLeafNode terminates a PSNode branch and doesn't have any child nodes attached.
-    A value embedded by a PSLeafNode is not enumerable and doesn't contain any object properties.
+### `[PSCollectionNode]`
 
-    ### `[PSCollectionNode]`
+A PSCollectionNode represents a PSNode containing a collection child nodes.
+A value embedded by a PSCollectionNode is enumerable or contains object properties.
 
-    A PSCollectionNode represents a PSNode containing a collection child nodes.
-    A value embedded by a PSCollectionNode is enumerable or contains object properties.
+### `[PSListNode]`
 
-    ### `[PSListNode]`
+A PSListNode represents a  PSNode listing any number (or none) child nodes.
+A value embedded by a PSListNode supports the `IList` interface but excludes any value that.
+support the IDictionary interface.
 
-    A PSListNode represents a  PSNode listing any number (or none) child nodes.
-    A value embedded by a PSListNode supports the `IList` interface but excludes any value that.
-    support the IDictionary interface.
+### `[PSMapNode]`
 
-    ### `[PSMapNode]`
+A PSMapNode represents a PSNode containing any number (or none) child nodes.
+A value embedded by a PSMapNode supports the IDictionary interface or contains object properties.
 
-    A PSMapNode represents a PSNode containing any number (or none) child nodes.
-    A value embedded by a PSMapNode supports the IDictionary interface or contains object properties.
+### `[PSDictionaryNode]`
 
-    ### `[PSDictionaryNode]`
+A PSDictionaryNode represents a PSNode containing any number (or none) child nodes.
+A value embedded by a PSDictionaryNode supports the IDictionary interface.
 
-    A PSDictionaryNode represents a PSNode containing any number (or none) child nodes.
-    A value embedded by a PSDictionaryNode supports the IDictionary interface.
+### `[PSObjectNode]`
 
-    ### `[PSObjectNode]`
+A PSObjectNode represents a PSNode containing any number (or none) child nodes.
+A value embedded by a PSObjectNode contains object properties meaning that it is either of type
+`[PSCustomObject]` or `[ComponentModel.Component]`.
 
-    A PSObjectNode represents a PSNode containing any number (or none) child nodes.
-    A value embedded by a PSObjectNode contains object properties meaning that it is either of type
-    `[PSCustomObject]` or `[ComponentModel.Component]`.
+## Constructors
 
-    ## Constructors
+There are no noteworthy constructors.
+To create a new PSNode instance, use the static `[PSNode]::ParseInput(<Object-Graph>)]`
+method or the `ChildNodes` property or `GetChildNode(<name>)` of an existing PSNode
+instance
 
-    There are no noteworthy constructors.
-    To create a new PSNode instance, use the static [`[PSNode]::ParseInput(<Object-Graph>)]
-    method or the `ChildNodes` property or `GetChildNode(<name>)` of an existing PSNode
-    instance
+## Properties
 
-    ## Properties
+### `Name` (ReadOnly)
 
-    ### `Name` (ReadOnly)
+The name of the embedded property defined by its parent.
+The name is `$Null` if the embedded node is the root node.
 
-    The name of the embedded property defined by its parent.
-    The name is `$Null` if the embedded node is the root node.
+### `Value`
 
-    ### `Value`
+The actual object, item, property or value embedded by the PSNode.
+The value might be modified but should be of the same structure (`[PSLeafNode]`, `[PSListNode]`,
+`[PSDictionaryNode]` or `[PSObjectNode]`) as the original node type.
 
-    The actual object, item, property or value embedded by the PSNode.
-    The value might be modified but should be of the same structure (`[PSLeafNode]`, `[PSListNode]`,
-    `[PSDictionaryNode]` or `[PSObjectNode]`) as the original node type.
+### `Depth` (ReadOnly)
 
-    ### `Depth` (ReadOnly)
+The depth where the current PSNode resides in the PSNode hierarchy (aka tree).
+An error will occur if the depth exceed the `MaxDepth` setting.
 
-    The depth where the current PSNode resides in the PSNode hierarchy (aka tree).
-    An error will occur if the depth exceed the `MaxDepth` setting.
+### `MaxDepth`
 
-    ### `ValueType` (ReadOnly)
+The maximum iteration depth of the embedded graph object.
+The `MaxDepth` value can be read at every level but can only be set on the root node:
+`[PSNode].RootNode.MaxDepth = <Maximum Depth>`
 
-    The type of the value embedded by the PSNode.
-    `$Null` if the embedded value is `$Null`
+### `ValueType` (ReadOnly)
 
-    ### `NodeOrigin` (ReadOnly)
+The type of the value embedded by the PSNode.
+`$Null` if the embedded value is `$Null`
 
-    Defines whether the parent node is a `[PSListNode]` type, a `[PSMapNode]` type.
-    The NodeOrigin is `Root` if the current node has no parent node.
+### `NodeOrigin` (ReadOnly)
 
-    ### `ParentNode` (ReadOnly)
+Defines whether the parent node is a `[PSListNode]` type, a `[PSMapNode]` type.
+The NodeOrigin is `Root` if the current node has no parent node.
 
-    Refers to node containing the current PSNode and possible siblings.
+### `ParentNode` (ReadOnly)
 
-    ### `RootNode` (ReadOnly)
+Refers to node containing the current PSNode and possible siblings.
 
-    Refers to the top node containing the current PSNode and all its decedents.
+### `RootNode` (ReadOnly)
 
-    ### `ChildNodes` (ReadOnly)
+Refers to the top node containing the current PSNode and all its decedents.
 
-    (`[PSCollectionNodes]` only)
-    Returns all the child nodes contained by the current PSNode.
-    To retrieve a specific child node, use the `GetChildNode(<Name>)` method.
+### `ChildNodes` (ReadOnly) (`[PSCollectionNodes]` only)
 
-    ### `Count` (ReadOnly)
+Returns all the child nodes contained by the current PSNode.
+To retrieve a specific child node, use the `GetChildNode(<Name>)` method.
 
-    (`[PSCollectionNodes]` only)
-    Returns the number of items or properties contained by the embedded value.
-    This number is equal to the number of child nodes contained by the current node.
+### `DescendantNodes` (ReadOnly) (`[PSCollectionNodes]` only)
 
-    ### `Names` (ReadOnly)
+Returns all the descendant nodes (up and till the `$MaxDepth` level) contained
+by the current PSNode.
 
-    (`[PSCollectionNodes]` only)
-    Returns the property or key names of the embedded value. If the PSNode is of
-    `[PSListNode]` type list a indices (starting from zero) is returned.
-    The name of each child node is equal to the name (or index) that identifies item
-    of the embedded value
+### `Count` (ReadOnly) (`[PSCollectionNodes]` only)
 
-    ### `Values` (ReadOnly)
+Returns the number of items or properties contained by the embedded value.
+This number is equal to the number of child nodes contained by the current node.
 
-    Returns all the value of the items or properties of the embedded value.
-    A PSNode derived from a `[PSLeafNode]` type doesn't have a `Values` property.
+### `Names` (ReadOnly) (`[PSCollectionNodes]` only)
 
-    ### `Path` (ReadOnly)
+Returns the property or key names of the embedded value. If the PSNode is of
+`[PSListNode]` type list a indices (starting from zero) is returned.
+The name of each child node is equal to the name (or index) that identifies item
+of the embedded value
 
-    Returns all the branch of PSNodes starting from the root PSNode up and till
-    the current PSNode
+### `Values` (ReadOnly) (`[PSCollectionNodes]` only)
 
-    ### `PathName` (ReadOnly)
+Returns all the value of the items or properties of the embedded value.
+A PSNode derived from a `[PSLeafNode]` type doesn't have a `Values` property.
 
-    Returns an unique path (string) identifying the current node in the PSNode tree
-    starting from the root node.
-    The path might be used to directly target the property or item of a object-graph
-    aka the value contained by the root node.
+### `Path` (ReadOnly)
 
-    ## Methods
+Returns all the branch of PSNodes starting from the root PSNode up and till
+the current PSNode
 
-    ### `[PSNode]::ParseInput(<object-graph? [, <maximal depth = 10>])`
+### `PathName` (ReadOnly)
 
-    This static method converts a object-graph to a [PSNode] structure and supplies access
-    to the underlying child nodes.
-    The `<maximal depth>` argument, set the maximal depth of the properties  that will be
-    recursively retrieve. When the maximal depth is reached, an error is throw.
-    The default maximal depth is defined by the static property `[PSNode]::MaxDepth` (default: 10)
+Returns an unique path (string) identifying the current node in the PSNode tree
+starting from the root node.
+The path might be used to directly target the property or item of a object-graph
+aka the value contained by the root node.
 
-    ### `GetChildNode(<name>)`
+## Methods
 
-    (`[PSCollectionNodes]` only)
-    Returns a specific child node (`[PSNode]`) selected by the name (or index) of the embedded
+### `[PSNode]::ParseInput(<object-graph> [, <maximal depth = 10>])`
 
-    ### `GetItem(<name>)`
+This static method converts a object-graph to a [PSNode] structure and supplies access
+to the underlying child nodes.
+The `<maximal depth>` argument, set the maximal depth of the properties  that will be
+recursively retrieve. When the maximal depth is reached, an error is throw.
+The default maximal depth is defined by the static property `[PSNode]::MaxDepth` (default: 10)
 
-    (`[PSCollectionNodes]` only)
-    Returns the value of a specific item identified by `<name>` of the embedded collection
-    or object.
+### `GetChildNode(<name>)` (`[PSCollectionNodes]` only)
 
-    ### `SetItem(<name>, <value>)`
+Returns a specific child node (`[PSNode]`) selected by the name (or index) of the embedded
 
-    (`[PSCollectionNodes]` only)
-    Sets the value of a specific item identified by `<name>` of the embedded collection
-    or object. The new value should be of the same structure (`[PSLeafNode]`, `[PSListNode]`,
-    `[PSDictionaryNode]` or `[PSObjectNode]`) as the original node type.
+> [!Note]
+> The `GetChildNode` has a Shorthand ("alias"): `_(<name>)` which shouldn't be used
+> in scripts as the its name or functionality might change in the future
 
-    ### `Contains(<name>)`
+### `GetDescendentNode(<path>)` (`[PSCollectionNodes]` only)
 
-    (`[PSCollectionNodes]` only)
-    Determines whether a specific item identified by `<name>` is contained by th embedded
-    collection or object.
+Returns a specific child node (`[PSNode]`) selected by the path of the embedded object
+The path might be either:
+
+* As [String] a "dot-property" selection as defined by the `PathName` property a specific node.
+* A array of strings (dictionary keys or Property names) and/or Integers (list indices).
+* A object (`PSNode[]`) list where each `Name` property defines the path
+
+> [!Note]
+> The `GetDescendentNode` has a Shorthand ("alias"): `Get(<name>)` which shouldn't be used
+> in scripts as the its name or functionality might change in the future
+
+### `GetDescendentNodes(<generations>)` (`[PSCollectionNodes]` only)
+
+Returns all descendant nodes of the current node for a the defined number of generations.
+
+> [!Note]
+> The number of generations will not surpass the `MaxDepth` defined at the root.
+
+### `GetItem(<name>)` (`[PSCollectionNodes]` only)
+
+Returns the value of a specific item identified by `<name>` of the embedded collection
+or object.
+
+### `SetItem(<name>, <value>)` (`[PSCollectionNodes]` only)
+
+Sets the value of a specific item identified by `<name>` of the embedded collection
+or object. The new value should be of the same structure (`[PSLeafNode]`, `[PSListNode]`,
+`[PSDictionaryNode]` or `[PSObjectNode]`) as the original node type.
+
+### `Contains(<name>)` (`[PSCollectionNodes]` only)
+
+Determines whether a specific item identified by `<name>` is contained by th embedded
+collection or object.
 #>
+
+Using NameSpace System.Management.Automation.Language
 enum PSNodeOrigin { Root; List; Map}
 
 Class PSNode {
@@ -196,7 +226,7 @@ Class PSNode {
     hidden $_Name
     [Int]$Depth
     hidden $_Value
-    hidden [Int]$MaxDepth = [PSNode]::DefaultMaxDepth
+    hidden [Int]$_MaxDepth = [PSNode]::DefaultMaxDepth
     hidden [PSNodeOrigin]$_NodeOrigin
     [PSNode]$ParentNode
     [PSNode]$RootNode = $this               # This will be overwritten by the Append method
@@ -216,8 +246,21 @@ Class PSNode {
         }
     }
 
-    hidden [Object] get_Name() {
+    [Object] get_Name() {
         return ,$this._Name
+    }
+
+    [Object] get_MaxDepth() {
+        return $this.RootNode._MaxDepth
+    }
+
+    hidden set_MaxDepth($MaxDepth) {
+        if ($this.NodeOrigin -eq 'Root') {
+            $this._MaxDepth = $MaxDepth
+        }
+        else {
+            Throw 'The MaxDepth can only be set at the root node: [PSNode].RootNode.MaxDepth = <Maximum Depth>'
+        }
     }
 
     hidden [Object] get_NodeOrigin()  { return [PSNodeOrigin]$this._NodeOrigin }
@@ -248,15 +291,17 @@ Class PSNode {
 
     static [PSNode] ParseInput($Object, [int]$MaxDepth) {
         $Node = [PSNode]::parseInput($Object)
-        $Node.MaxDepth = $MaxDepth
+        $Node.RootNode  = $Node
+        $Node._MaxDepth = $MaxDepth
         return $Node
     }
 
     hidden [PSNode] Append($Object) {
         $Node = [PSNode]::ParseInput($Object)
         $Node.Depth      = $this.Depth + 1
-        $Node.ParentNode = $this
         $Node.RootNode   = $this.RootNode
+        $Node.ParentNode = $this
+
         return $Node
     }
 
@@ -294,17 +339,91 @@ Class PSLeafNode : PSNode {
 
 Class PSCollectionNode : PSNode {
     hidden [bool]MaxDepthReached() {
-        $MaxDepthReached = $this.Depth -ge $this.RootNode.MaxDepth
+        $MaxDepthReached = $this.Depth -ge $this.RootNode._MaxDepth
         if ($MaxDepthReached -and -not $this.WarnedMaxDepth) {
-            Write-Warning "$($this.Path) reached the maximum depth of $($this.RootNode.MaxDepth)."
+            Write-Warning "$($this.Path) reached the maximum depth of $($this.RootNode._MaxDepth)."
             $this.WarnedMaxDepth = $true
         }
         return $MaxDepthReached
     }
 
-    hidden [Object]get_ChildNodes()      { return ,[PSNode[]]@($this.GetChildNodes($false)) }
-    hidden [Object]get_DescendantNodes() { return ,[PSNode[]]@($this.GetChildNodes($true)) }
-    hidden [Object]_($Name)              { return $this.GetChildNode($Name) } # Shorthand ("alias") for GetChildNode
+    hidden WarnSelector ([PSCollectionNode]$Node, [String]$Name) {
+        if ($Node -is [PSListNode]) {
+            $SelectionName  = "'$Name'"
+            $CollectionType = 'list'
+        }
+        else {
+            $SelectionName  = "[$Name]"
+            $CollectionType = 'list'
+        }
+        Write-Warning "Expected $SelectionName to be a $CollectionType selector for: <Object>$($Node.PathName)"
+    }
+
+    hidden[Collections.Generic.List[Ast]] GetAstSelectors ($Ast) {
+        $List = [Collections.Generic.List[Ast]]::new()
+        if ($Ast -isnot [Ast]) {
+            $Ast = [Parser]::ParseInput("`$_$Ast", [ref]$Null, [ref]$Null)
+            $Ast = $Ast.EndBlock.Statements.PipeLineElements.Expression
+        }
+        if ($Ast -is [IndexExpressionAst]) {
+            $List.AddRange($this.GetAstSelectors($Ast.Target))
+            $List.Add($Ast)
+        }
+        elseif ($Ast -is [MemberExpressionAst]) {
+            $List.AddRange($this.GetAstSelectors($Ast.Expression))
+            $List.Add($Ast)
+        }
+        elseif ($Ast.Extent.Text -ne '$_') {
+            Throw "Parse error: $($Ast.Extent.Text)"
+        }
+        return $List
+    }
+
+    [Object]GetDescendentNode($Path) {
+        if ($Path -is [String]) {
+            $String = if ($Path.StartsWith('.') -or $Path.StartsWith('[')) { "`$_$Path"} else { "`$_.$Path"}
+            $Ast  = [Parser]::ParseInput($String, [ref]$Null, [ref]$Null)
+            $Ast = $Ast.EndBlock.Statements.PipeLineElements.Expression
+            $Selectors = $this.GetAstSelectors($Ast)
+        }
+        elseif ($Path -is [PSNode]) { $Selectors = $Path.Path }
+        else { $Selectors = $Path }
+        $Node = $this
+        foreach ($Selector in $Selectors) {
+            if ($Node -is [PSLeafNode]) {
+                Throw "Can not select child node in <object>$($Node.PathName) as it is a leaf node."
+            }
+            elseif ($Selector -is [IndexExpressionAst]) {
+                $Name = $Selector.Index.Value
+                if ($Node -isnot [PSListNode]) { $this.WarnSelector($Node, $Name) }
+            }
+            elseif ($Selector -is [MemberExpressionAst]) {
+                $Name = $Selector.Member.Value
+                if ($Node -isnot [PSMapNode]) { $this.WarnSelector($Node, $Name) }
+            }
+            else {
+                $Name = if ($Selector.PSObject.Properties['Name']) { $Selector.Name } else { $Selector }
+                if ($Selector -is [PSNode]) {
+                    if ($Selector.PSNodeOrigin -eq 'List' -and  $Node -isnot [PSListNode]) { $this.WarnSelector($Node, $Name) }
+                    if ($Selector.PSNodeOrigin -eq 'Map'  -and  $Node -isnot [PSMapNode])  { $this.WarnSelector($Node, $Name) }
+                }
+                elseif ($Name -is [Int]) {
+                    if ($Node.ValueType.IsGenericType -and $Node.ValueType.GetGenericArguments()[0].Name -eq 'String') { $this.WarnSelector($Node, $Name) }
+                }
+                else {
+                    if ($Node -isnot [PSMapNode]) {$this.WarnSelector($Node, $Name) }
+                }
+            }
+            if ($Null -ne $Name) { $Node = $Node.GetChildNode($Name) } # Not sure yet whether $Null should selected the current node or the root node...
+        }
+        return $Node
+    }
+
+    [Collections.Generic.List[PSNode]]GetDescendentNodes() { return $this.GetDescendentNodes(0) }
+    hidden [Object]get_ChildNodes()      { return ,[PSNode[]]@($this.GetDescendentNodes(0)) }
+    hidden [Object]get_DescendantNodes() { return ,[PSNode[]]@($this.GetDescendentNodes(-1)) }
+    hidden [Object]_($Name)              { return $this.GetChildNode($Name) }       # CLI Shorthand ("alias") for GetChildNode (don't use in scripts)
+    hidden [Object]Get($Path)            { return $this.GetDescendentNode($Path) }  # CLI Shorthand ("alias") for GetDescendentNode (don't use in scripts)
 }
 
 Class PSListNode : PSCollectionNode {
@@ -336,7 +455,7 @@ Class PSListNode : PSCollectionNode {
         $this._Value[$Index] = $Value
     }
 
-    hidden [Collections.Generic.List[PSNode]]GetChildNodes([Bool]$Recurse) {
+    [Collections.Generic.List[PSNode]]GetDescendentNodes([Int]$Levels) {
         $List = [Collections.Generic.List[PSNode]]::new()
         if (-not $this.MaxDepthReached()) {
             for ($Index = 0; $Index -lt $this._Value.Get_Count(); $Index++) {
@@ -344,8 +463,8 @@ Class PSListNode : PSCollectionNode {
                 $Node._NodeOrigin = 'List'
                 $Node._Name = $Index
                 $List.Add($Node)
-                if ($Recurse -and $Node -is [PSCollectionNode]) {
-                    $list.AddRange($Node.GetChildNodes($true))
+                if ($Levels -ne 0 -and $Node -is [PSCollectionNode]) {
+                    $list.AddRange($Node.GetDescendentNodes($Levels - 1))
                 }
             }
         }
@@ -366,7 +485,7 @@ Class PSListNode : PSCollectionNode {
 
     [Int]GetHashCode() {
         $HashCode = '@()'.GetHashCode()
-        foreach ($Node in $this.GetChildNodes($false)) {
+        foreach ($Node in $this.GetDescendentNodes(-1)) {
             $HashCode = $HashCode -bxor $Node.GetHashCode()
         }
         # Shift the bits to make the level unique
@@ -379,7 +498,7 @@ Class PSMapNode : PSCollectionNode {
 
     [Int]GetHashCode() {
         $HashCode = '@{}'.GetHashCode()
-        foreach ($Node in $this.GetChildNodes($false)) {
+        foreach ($Node in $this.GetDescendentNodes(-1)) {
             $HashCode = $HashCode -bxor "$($Node._Name)=$($Node.GetHashCode())".GetHashCode()
         }
         return $HashCode
@@ -415,7 +534,7 @@ Class PSDictionaryNode : PSMapNode {
         $this._Value[$Key] = $Value
     }
 
-    hidden [Collections.Generic.List[PSNode]]GetChildNodes([Bool]$Recurse) {
+    [Collections.Generic.List[PSNode]]GetDescendentNodes([Int]$Levels) {
         $List = [Collections.Generic.List[PSNode]]::new()
         if (-not $this.MaxDepthReached()) {
             foreach($Key in $this._Value.get_Keys()) {
@@ -423,8 +542,8 @@ Class PSDictionaryNode : PSMapNode {
                 $Node._NodeOrigin = 'Map'
                 $Node._Name = $Key
                 $List.Add($Node)
-                if ($Recurse -and $Node -is [PSCollectionNode]) {
-                    $list.AddRange($Node.GetChildNodes($true))
+                if ($Levels -ne 0 -and $Node -is [PSCollectionNode]) {
+                    $list.AddRange($Node.GetDescendentNodes(($Levels - 1)))
                 }
             }
         }
@@ -472,7 +591,7 @@ Class PSObjectNode : PSMapNode {
         $this._Value.PSObject.Properties[$Name].Value = $Value
     }
 
-    hidden [Collections.Generic.List[PSNode]]GetChildNodes([Bool]$Recurse) {
+    [Collections.Generic.List[PSNode]]GetDescendentNodes([Int]$Levels) {
         $List = [Collections.Generic.List[PSNode]]::new()
         if (-not $this.MaxDepthReached()) {
             foreach($Property in $this._Value.PSObject.Properties) {
@@ -480,8 +599,8 @@ Class PSObjectNode : PSMapNode {
                 $Node._NodeOrigin = 'Map'
                 $Node._Name = $Property.Name
                 $List.Add($Node)
-                if ($Recurse -and $Node -is [PSCollectionNode]) {
-                    $list.AddRange($Node.GetChildNodes($true))
+                if ($Levels -ne 0 -and $Node -is [PSCollectionNode]) {
+                    $list.AddRange($Node.GetDescendentNodes($Levels - 1))
                 }
             }
         }

--- a/Source/Public/Get-Node.ps1
+++ b/Source/Public/Get-Node.ps1
@@ -15,8 +15,11 @@ function Get-Node {
         [Parameter(Mandatory = $true)]
         $ObjectGraph,
 
-        [Parameter(Mandatory = $true, ValueFromPipeLine = $true, ValueFromPipelineByPropertyName = $true)]
-        $Path
+        [Parameter(ValueFromPipeLine = $true, ValueFromPipelineByPropertyName = $true)]
+        $Path,
+
+        [Int]
+        $MaxDepth
     )
     begin {
         function StopError($Exception, $Id = 'IncorrectArgument', $Group = [Management.Automation.ErrorCategory]::SyntaxError, $Object){
@@ -25,74 +28,18 @@ function Get-Node {
             $PSCmdlet.ThrowTerminatingError([System.Management.Automation.ErrorRecord]::new($Exception, $Id, $Group, $Object))
         }
 
-        function WarnSelector ([PSCollectionNode]$Node, $Name) {
-            if ($Node -is [PSListNode]) {
-                $SelectionName  = "'$Name'"
-                $CollectionType = 'list'
-            }
-            else {
-                $SelectionName  = "[$Name]"
-                $CollectionType = 'list'
-            }
-            Write-Warning "Expected $SelectionName to be a $CollectionType selector for: <Object>$($Node.PathName)"
+        if ($PSBoundParameters.ContainsKey('MaxDepth')) {
+            $Node = [PSNode]::ParseInput($ObjectGraph, $MaxDepth)
         }
-
-        function GetAstSelectors ([Ast]$Ast) {
-            if ($Ast -isnot [Ast]) {
-                $Ast = [Parser]::ParseInput("`$_$Ast", [ref]$Null, [ref]$Null)
-                $Ast = $Ast.EndBlock.Statements.PipeLineElements.Expression
-            }
-            if ($Ast -is [IndexExpressionAst]) {
-                GetAstSelectors $Ast.Target
-                $Ast
-            }
-            elseif ($Ast -is [MemberExpressionAst]) {
-                GetAstSelectors $Ast.Expression
-                $Ast
-            }
-            elseif ($Ast.Extent.Text -ne '$_') {
-                Throw "Parse error: $($Ast.Extent.Text)"
-            }
+        else {
+            $Node = [PSNode]::ParseInput($ObjectGraph)
         }
-        $RootNode = [PSNode]::ParseInput($ObjectGraph)
     }
     process {
-        if ($Path -is [String] -and ($Path.StartsWith('.') -or $Path.StartsWith('['))) {
-            $Ast  = [Parser]::ParseInput("`$_$Path", [ref]$Null, [ref]$Null)
-            $Ast = $Ast.EndBlock.Statements.PipeLineElements.Expression
-            $Selectors = GetAstSelectors $Ast
-        }
-        elseif ($Path -is [PSNode]) { $Selectors = $Path.Path }
-        else { $Selectors = $Path }
-        $Node = $RootNode
-        foreach ($Selector in $Selectors) {
-            if ($Node -is [PSLeafNode]) {
-                StopError "Can not select child node in <object>$($Node.PathName) as it is a leaf node."
-            }
-            elseif ($Selector -is [IndexExpressionAst]) {
-                $Name = $Selector.Index.Value
-                if ($Node -isnot [PSListNode]) { WarnSelector $Node $Name }
-            }
-            elseif ($Selector -is [MemberExpressionAst]) {
-                $Name = $Selector.Member.Value
-                if ($Node -isnot [PSMapNode]) { WarnSelector $Node $Name }
-            }
-            else {
-                $Name = if ($Selector.PSObject.Properties['Name']) { $Selector.Name } else { $Selector }
-                if ($Selector -is [PSNode]) {
-                    if ($Selector.PSNodeOrigin -eq 'List' -and  $Node -isnot [PSListNode]) { WarnSelector $Node $Name }
-                    if ($Selector.PSNodeOrigin -eq 'Map'  -and  $Node -isnot [PSMapNode])  { WarnSelector $Node $Name }
-                }
-                elseif ($Name -is [Int]) {
-                    if ($Node.Type.IsGenericType -and $Node.Type.GetGenericArguments()[0].Name -eq 'String') { WarnSelector $Node $Name }
-                }
-                else {
-                    if ($Node -isnot [PSMapNode]) {WarnSelector $Node $Name }
-                }
-            }
-            if ($Null -ne $Name) { $Node = $Node.GetChildNode($Name) } # Not sure yet whether $Null should selected the current node or the root node...
-        }
-        $Node
+        if ($ObjectGraph -is [PSNode]) { $Node = $ObjectGraph }
+        else { $Node = [PSNode]::ParseInput($ObjectGraph) }
+        # try { $Node.GetDescendentNode($Path) } catch { StopError $_ }
+        $Node.GetDescendentNode($Path)
     }
 }
 

--- a/Tests/Get-ChildNode.Tests.ps1
+++ b/Tests/Get-ChildNode.Tests.ps1
@@ -52,13 +52,18 @@ Describe 'Get-ChildNode' {
             $Nodes.Count | Should -Be 14
         }
 
+        it 'All decedent nodes including self' {
+            $Nodes = $Object | Get-ChildNode -Recurse -IncludeSelf
+            $Nodes.Count | Should -Be 15
+        }
+
         it 'All leaf nodes' {
-            $Nodes = $Object | Get-ChildNode -LeafNode
+            $Nodes = $Object | Get-ChildNode -Leaf
             $Nodes.Name  | Should -Be Comment
         }
 
         it 'All decedent leaf nodes' {
-            $Nodes = $Object | Get-ChildNode -LeafNode -Recurse
+            $Nodes = $Object | Get-ChildNode -Leaf -Recurse
             $Nodes.Count | Should -Be 10
         }
 
@@ -78,7 +83,7 @@ Describe 'Get-ChildNode' {
         }
 
         it 'All map leaf nodes' {
-            $Nodes = $Object | Get-ChildNode -Include * -LeafNode
+            $Nodes = $Object | Get-ChildNode -Include * -Leaf
             $Nodes.Name  | Should -Be Comment
         }
 
@@ -88,7 +93,7 @@ Describe 'Get-ChildNode' {
         }
 
         it 'All decedent map leaf nodes' {
-            $Nodes = $Object | Get-ChildNode -Include * -Recurse -LeafNode
+            $Nodes = $Object | Get-ChildNode -Include * -Recurse -Leaf
             $Nodes.Count | Should -Be 10
         }
 

--- a/Tests/ObjectParser.Tests.ps1
+++ b/Tests/ObjectParser.Tests.ps1
@@ -69,6 +69,7 @@ Describe 'PSNode' {
             $ItemNode = $Node.GetChildNode('String')
             $ItemNode | Should -BeOfType PSNode
             $ItemNode | Should -BeOfType PSLeafNode
+            $ItemNode.Value     | Should -Be $Object.String
             $ItemNode.ValueType | Should -Be $Object.String.GetType()
         }
 
@@ -96,6 +97,36 @@ Describe 'PSNode' {
             $ItemNode | Should -BeOfType PSMapNode
             $ItemNode | Should -BeOfType PSObjectNode
             $ItemNode.ValueType | Should -Be $Object.PSCustomObject.GetType()
+        }
+    }
+
+    Context 'Get descendent node' {
+        BeforeAll {
+            $Node = [PSNode]::ParseInput($Object)
+        }
+
+        it 'String' {
+            $ItemNode = $Node.GetDescendentNode('String')
+            $ItemNode | Should -BeOfType PSNode
+            $ItemNode | Should -BeOfType PSLeafNode
+            $ItemNode.Value     | Should -Be $Object.String
+            $ItemNode.ValueType | Should -Be $Object.String.GetType()
+        }
+
+        it 'String' {
+            $ItemNode = $Node.GetDescendentNode('.String')
+            $ItemNode | Should -BeOfType PSNode
+            $ItemNode | Should -BeOfType PSLeafNode
+            $ItemNode.Value     | Should -Be $Object.String
+            $ItemNode.ValueType | Should -Be $Object.String.GetType()
+        }
+
+        it 'Array' {
+            $ItemNode = $Node.GetDescendentNode('.Array[0].Comment')
+            $ItemNode | Should -BeOfType PSNode
+            $ItemNode | Should -BeOfType PSLeafNode
+            $ItemNode.Value     | Should -Be $Object.Array[0].Comment
+            $ItemNode.ValueType | Should -Be $Object.Array[0].Comment.GetType()
         }
     }
 

--- a/WhatsNew.md
+++ b/WhatsNew.md
@@ -1,3 +1,10 @@
+## 2024-01-29 0.0.12 (iRon)
+  - Fixes
+    - #31 "ComponentModel.Component does not parse correctly"
+
+  - Enhancements
+    - Improved `PathName` property performance
+
 ## 2024-01-27 0.0.11 (iRon)
   - Break changes
     - rename `-LeafNode` parameter from `Get-ChildNode` to just `-Leaf` to be consistent with `-ListChild`considering that the word `Node` is al ready in the cmdlet verb.

--- a/WhatsNew.md
+++ b/WhatsNew.md
@@ -1,0 +1,22 @@
+## 2024-01-27 0.0.11 (iRon)
+  - Break changes
+    - rename `-LeafNode` parameter from `Get-ChildNode` to just `-Leaf` to be consistent with `-ListChild`considering that the word `Node` is al ready in the cmdlet verb.
+
+  - Enhancements
+    - Object parser: uniform `MaxDepth` property (might only be set at the root node)
+    - Object parser: added: `GetDescendentNode(<path>)` (alias: `Get(<path>)`) method
+    - Object parser: added [help](https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/Sort-ObjectGraph.md)
+    - Get-ChildNode: Added `-Path` parameter
+    - Get-ChildNode: Added `-AtDepth` parameter
+    - Get-ChildNode: Added `-IncludeSelf` parameter
+
+
+## 2023-01-25 0.0.10 (iRon)
+  - Break changes
+    - Single property `Name` for both list `Index` and map `Key`
+
+  - Enhancements
+    - Included class accessor support: https://github.com/iRon7/Use-ClassAccessors
+      - Add (readonly) properties as e.g. `Type`
+      - Ability to change the embedded object property from the `Value` property
+    - Default display names: `Path`, `Name`, `Depth`, `Value`


### PR DESCRIPTION
  - Break changes
    - rename `-LeafNode` parameter from `Get-ChildNode` to just `-Leaf` to be consistent with `-ListChild`considering that the word `Node` is al ready in the cmdlet verb.

  - Enhancements
    - Object parser: uniform `MaxDepth` property (might only be set at the root node)
    - Object parser: added: `GetDescendentNode(<path>)` (alias: `Get(<path>)`) method
    - Object parser: added [help](https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/Sort-ObjectGraph.md)
    - Get-ChildNode: Added `-Path` parameter
    - Get-ChildNode: Added `-AtDepth` parameter
    - Get-ChildNode: Added `-IncludeSelf` parameter