### PR TITLE
Fixed #50, #51 and #53 and more

### DIFF
--- a/Build/Build-Docs.ps1
+++ b/Build/Build-Docs.ps1
@@ -1,0 +1,4 @@
+Get-ChildItem $PSScriptRoot\..\Source\Public\*.ps1 | ForEach-Object {
+    Write-Host $_
+    Get-MarkdownHelp $_ | Out-File -Encoding ASCII $PSScriptRoot\..\Docs\$($_.BaseName).md
+}

--- a/Docs/Compare-ObjectGraph.md
+++ b/Docs/Compare-ObjectGraph.md
@@ -5,7 +5,8 @@ Compare Object Graph
 
 ## Syntax
 
-```JavaScript
+```PowerShell
+Compare-ObjectGraph
     -InputObject <Object>
     -Reference <Object>
     [-PrimaryKey <String[]>]
@@ -13,7 +14,7 @@ Compare Object Graph
     [-MatchCase]
     [-MatchType]
     [-MatchOrder]
-    [-MaxDepth <Int32> = 10]
+    [-MaxDepth <Int32> = [PSNode]::DefaultMaxDepth]
     [<CommonParameters>]
 ```
 
@@ -154,7 +155,9 @@ The maximal depth to recursively compare each embedded property (default: 10).
 <tr><td>Type:</td><td></td></tr>
 <tr><td>Mandatory:</td><td>False</td></tr>
 <tr><td>Position:</td><td>Named</td></tr>
-<tr><td>Default value:</td><td><code>10</code></td></tr>
+<tr><td>Default value:</td><td><code>[PSNode]::DefaultMaxDepth</code></td></tr>
 <tr><td>Accept pipeline input:</td><td></td></tr>
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
+
+[comment]: <> (Created with Get-MarkdownHelp: Install-Script -Name Get-MarkdownHelp)

--- a/Docs/ConvertTo-Expression.md
+++ b/Docs/ConvertTo-Expression.md
@@ -120,7 +120,7 @@ PowerShell representation. The default value is 9.
 ## Inputs
 
 Any. Each objects provided through the pipeline will converted to an
-expression. To concatinate all piped objects in a single expression,
+expression. To concatenate all piped objects in a single expression,
 use the unary comma operator,  e.g.: ,$Object | ConvertTo-Expression
 
 ## Outputs
@@ -131,3 +131,5 @@ for each input object.
 ## Related Links
 
 * https://www.powershellgallery.com/packages/ConvertFrom-Expression
+
+[comment]: <> (Created with Get-MarkdownHelp: Install-Script -Name Get-MarkdownHelp)

--- a/Docs/Copy-ObjectGraph.md
+++ b/Docs/Copy-ObjectGraph.md
@@ -11,7 +11,7 @@ Copy-ObjectGraph
     [-ListAs <Object>]
     [-MapAs <Object>]
     [-ExcludeLeafs]
-    [-MaxDepth <Int32> = 10]
+    [-MaxDepth <Int32> = [PSNode]::DefaultMaxDepth]
     [<CommonParameters>]
 ```
 
@@ -23,16 +23,22 @@ Recursively ("deep") copies a object graph.
 
 ### Example 1: Deep copy a complete object graph into a new object graph
 
+
+```PowerShell
 $NewObjectGraph = Copy-ObjectGraph $ObjectGraph
 ```
 
 ### Example 2: Copy (convert) an object graph using common PowerShell arrays and PSCustomObjects
 
+
+```PowerShell
 $PSObject = Copy-ObjectGraph $Object -ListAs [Array] -DictionaryAs PSCustomObject
 ```
 
 ### Example 3: Convert a Json string to an object graph with (case insensitive) ordered dictionaries
 
+
+```PowerShell
 $PSObject = $Json | ConvertFrom-Json | Copy-ObjectGraph -DictionaryAs ([Ordered]@{})
 ```
 
@@ -95,7 +101,7 @@ If omitted, each leaf will be shallow copied
 <tr><td>Type:</td><td></td></tr>
 <tr><td>Mandatory:</td><td>False</td></tr>
 <tr><td>Position:</td><td>Named</td></tr>
-<tr><td>Default value:</td><td><code>10</code></td></tr>
+<tr><td>Default value:</td><td><code>[PSNode]::DefaultMaxDepth</code></td></tr>
 <tr><td>Accept pipeline input:</td><td></td></tr>
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
@@ -107,3 +113,5 @@ If omitted, each leaf will be shallow copied
 
 [1]: https://learn.microsoft.com/dotnet/api/system.management.automation.pscustomobject "PSCustomObject Class"
 [2]: https://learn.microsoft.com/dotnet/api/system.componentmodel.component "Component Class"
+
+[comment]: <> (Created with Get-MarkdownHelp: Install-Script -Name Get-MarkdownHelp)

--- a/Docs/Get-ChildNode.md
+++ b/Docs/Get-ChildNode.md
@@ -7,7 +7,7 @@ Gets the child nodes of an object-graph
 
 ```PowerShell
 Get-ChildNode
-    -ObjectGraph <Object>
+    -InputObject <Object>
     [-Path <Object>]
     [-Recurse]
     [-AtDepth <Int32[]>]
@@ -37,6 +37,8 @@ Gets the items and child items in one or more specified locations of an object-g
 ## Examples
 
 ### Example 1: Select all leaf nodes in a object graph
+
+```
 
 Given the following object graph:
 
@@ -84,6 +86,8 @@ PathName         Name    Depth Value
 
 ### Example 2: update a property
 
+```
+
 The following example selects all child nodes named `Comment` at a depth of `3`.
 Than filters the one that has an `Index` sibling with the value `2` and eventually
 sets the value (of the `Comment` node) to: 'Two to the Loo'.
@@ -120,7 +124,7 @@ See the [PowerShell Object Parser][1] For details on the `[PSNode]` properties a
 
 ## Parameter
 
-### <a id="-objectgraph">**`-ObjectGraph <Object>`**</a>
+### <a id="-inputobject">**`-InputObject <Object>`**</a>
 
 The concerned object graph or node.
 
@@ -158,7 +162,7 @@ The maximum depth of of a specific node that might be retrieved is define by the
 of the (root) node. To change the maximum depth the (root) node needs to be loaded first, e.g.:
 
 ```PowerShell
-Get-Node <ObjectGraph> -Depth 20 | Get-ChildNode ...
+Get-Node <InputObject> -Depth 20 | Get-ChildNode ...
 ```
 
 (See also: [`Get-Node`][2])
@@ -194,7 +198,7 @@ When defined, only returns nodes at the given depth(s).
 
 ### <a id="-listchild">**`-ListChild`**</a>
 
-Returns only nodes derived from a **list node**.
+Returns the closest nodes derived from a **list node**.
 
 <table>
 <tr><td>Type:</td><td></td></tr>
@@ -289,3 +293,5 @@ Includes the current node with the returned child nodes.
 
 [1]: https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/ObjectParser.md "PowerShell Object Parser"
 [2]: https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/Get-Node.md "Get-Node"
+
+[comment]: <> (Created with Get-MarkdownHelp: Install-Script -Name Get-MarkdownHelp)

--- a/Docs/Get-Node.md
+++ b/Docs/Get-Node.md
@@ -21,6 +21,8 @@ The Get-Node cmdlet gets the node at the specified property location of the supp
 
 ### Example 1: Parse a object graph to a node instance
 
+```
+
 The following example parses a hash table to `[PSNode]` instance:
 
 ```PowerShell
@@ -32,6 +34,8 @@ PathName Name Depth Value
 ```
 
 ### Example 2: select a sub node in an object graph
+
+```
 
 The following example parses a hash table to `[PSNode]` instance and selects the second (`0` indexed)
 item in the `My` map node
@@ -46,7 +50,7 @@ PathName Name Depth Value
 
 ## Parameter
 
-### <a id="-InputObject">**`-InputObject <Object>`**</a>
+### <a id="-inputobject">**`-InputObject <Object>`**</a>
 
 The concerned object graph or node.
 
@@ -101,3 +105,5 @@ The default `MaxDepth` is defined by `[PSNode]::DefaultMaxDepth = 10`.
 <tr><td>Accept pipeline input:</td><td></td></tr>
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
+
+[comment]: <> (Created with Get-MarkdownHelp: Install-Script -Name Get-MarkdownHelp)

--- a/Docs/Merge-ObjectGraph.md
+++ b/Docs/Merge-ObjectGraph.md
@@ -5,12 +5,13 @@ Merges two object graphs into one
 
 ## Syntax
 
-```JavaScript
+```PowerShell
+Merge-ObjectGraph
     -InputObject <Object>
     -Template <Object>
     [-PrimaryKey <String[]>]
     [-MatchCase]
-    [-MaxDepth <Int32> = 10]
+    [-MaxDepth <Int32> = [PSNode]::DefaultMaxDepth]
     [<CommonParameters>]
 ```
 
@@ -94,7 +95,9 @@ The maximal depth to recursively compare each embedded property (default: 10).
 <tr><td>Type:</td><td></td></tr>
 <tr><td>Mandatory:</td><td>False</td></tr>
 <tr><td>Position:</td><td>Named</td></tr>
-<tr><td>Default value:</td><td><code>10</code></td></tr>
+<tr><td>Default value:</td><td><code>[PSNode]::DefaultMaxDepth</code></td></tr>
 <tr><td>Accept pipeline input:</td><td></td></tr>
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
+
+[comment]: <> (Created with Get-MarkdownHelp: Install-Script -Name Get-MarkdownHelp)

--- a/Docs/Sort-ObjectGraph.md
+++ b/Docs/Sort-ObjectGraph.md
@@ -1,16 +1,17 @@
 <!-- markdownlint-disable MD033 -->
-# Sort-ObjectGraph
+# ConvertTo-SortedObjectGraph
 
 Sort object graph
 
 ## Syntax
 
-```JavaScript
+```PowerShell
+ConvertTo-SortedObjectGraph
     -InputObject <Object>
     [-PrimaryKey <String[]>]
     [-MatchCase]
     [-Descending]
-    [-MaxDepth <Int32> = 10]
+    [-MaxDepth <Int32> = [PSNode]::DefaultMaxDepth]
     [<CommonParameters>]
 ```
 
@@ -95,7 +96,9 @@ The maximal depth to recursively compare each embedded property (default: 10).
 <tr><td>Type:</td><td></td></tr>
 <tr><td>Mandatory:</td><td>False</td></tr>
 <tr><td>Position:</td><td>Named</td></tr>
-<tr><td>Default value:</td><td><code>10</code></td></tr>
+<tr><td>Default value:</td><td><code>[PSNode]::DefaultMaxDepth</code></td></tr>
 <tr><td>Accept pipeline input:</td><td></td></tr>
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
+
+[comment]: <> (Created with Get-MarkdownHelp: Install-Script -Name Get-MarkdownHelp)

--- a/ObjectGraphTools.psd1
+++ b/ObjectGraphTools.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ObjectGraphTools.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.0.19'
+    ModuleVersion = '0.0.20'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Source/Public/ConvertTo-Expression.ps1
+++ b/Source/Public/ConvertTo-Expression.ps1
@@ -30,7 +30,7 @@
 
 .INPUTS
     Any. Each objects provided through the pipeline will converted to an
-    expression. To concatinate all piped objects in a single expression,
+    expression. To concatenate all piped objects in a single expression,
     use the unary comma operator,  e.g.: ,$Object | ConvertTo-Expression
 
 .OUTPUTS

--- a/Source/Public/Copy-ObjectGraph.ps1
+++ b/Source/Public/Copy-ObjectGraph.ps1
@@ -47,9 +47,9 @@ function Copy-ObjectGraph {
         [Parameter(Mandatory = $true, ValueFromPipeLine = $true)]
         $InputObject,
 
-        $ListAs,
+        [ValidateNotNull()]$ListAs,
 
-        $MapAs,
+        [ValidateNotNull()]$MapAs,
 
         [Switch]$ExcludeLeafs,
 
@@ -62,19 +62,9 @@ function Copy-ObjectGraph {
             $PSCmdlet.ThrowTerminatingError([System.Management.Automation.ErrorRecord]::new($Exception, $Id, $Group, $Object))
         }
 
-        $ListNode = if ($PSBoundParameters.ContainsKey('ListAs')) {
-            if ($ListAs -is [String] -or $ListAs -is [Type]) {
-                try { $ListAs = New-Object -Type $ListAs } catch { StopError $_ }
-            }
-            [PSNode]::ParseInput($ListAs)
-        }
+        $ListType = if ($ListAs -is [String] -or $ListAs -is [Type]) { $ListAs -as [Type] } elseif ($Null -ne $ListAs) { $ListAs.GetType() }
+        $MapType  = if ($MapAs  -is [String] -or $MapAs  -is [Type]) { $MapAs  -as [Type] } elseif ($Null -ne $MapAs)  { $MapAs.GetType() }
 
-        $MapNode = if ($PSBoundParameters.ContainsKey('MapAs')) {
-            if ($MapAs -is [String] -or $MapAs -is [Type]) {
-                try { $MapAs = New-Object -Type $MapAs } catch { StopError $_ }
-            }
-            [PSNode]::ParseInput($MapAs)
-        }
 
         if (($ListNode -is [PSMapNode] -and $MapNode -isnot [PSMapNode]) -or ($MapNode -is [PSListNode] -and $ListNode -isnot [PSListNode])) {
             $ListNode, $DictionaryNode = $DictionaryNode, $ListNode
@@ -114,6 +104,6 @@ function Copy-ObjectGraph {
     }
     process {
         $PSNode = [PSNode]::ParseInput($InputObject, $MaxDepth)
-        CopyObject $PSNode -ListType $ListNode.ValueType -MapType $MapNode.ValueType -ExcludeLeafs:$ExcludeLeafs
+        CopyObject $PSNode -ListType $ListType -MapType $MapType -ExcludeLeafs:$ExcludeLeafs
     }
 }

--- a/Tests/Copy-ObjectGraph.Tests.ps1
+++ b/Tests/Copy-ObjectGraph.Tests.ps1
@@ -68,5 +68,11 @@ Describe 'Copy-ObjectGraph' {
             $PSCustomObject = @{ 1 = 'a' } | Copy-ObjectGraph -MapAs PSCustomObject
             $PSCustomObject.1 | Should -Be a
         }
+
+        It '#50 -ListAs Array gives error' {
+            $Copy = Copy-ObjectGraph $Object -ListAs array
+            ,$Copy.Array | Should -BeOfType Array
+            $Copy | Compare-ObjectGraph $Object -IsEqual | Should -BeTrue
+        }
     }
 }

--- a/Tests/Get-ChildNode.Tests.ps1
+++ b/Tests/Get-ChildNode.Tests.ps1
@@ -69,7 +69,7 @@ Describe 'Get-ChildNode' {
 
         it 'All list child nodes' {
             $Nodes = $Object | Get-ChildNode -ListChild
-            $Nodes | Should -BeNullOrEmpty
+            $Nodes.Name | Sort-Object | Should -Be 0, 1, 2
         }
 
         it 'All decedent list child nodes' {
@@ -151,6 +151,15 @@ Describe 'Get-ChildNode' {
             $Nodes = $Object | Get-ChildNode -Recurse -Exclude Com*, Nam?
             $Nodes.Count | Should -Be 4
             $Nodes.Name | Sort-Object -Unique | Should -Be 'Data', 'Index'
+        }
+    }
+
+    Context 'Warnings' {
+
+        it 'Is a leaf node' {
+            $LeafNode = $Object | Get-ChildNode Comment
+            $Output = $LeafNode | Get-ChildNode 3>&1
+            $Output.where{$_ -is [System.Management.Automation.WarningRecord]}.Message | Should -BeLike  '*is a leaf node*'
         }
     }
 }

--- a/Tests/ObjectParser.Tests.ps1
+++ b/Tests/ObjectParser.Tests.ps1
@@ -233,6 +233,17 @@ Describe 'PSNode' {
         }
     }
 
+    Context 'Get leaf nodes' {
+        BeforeAll {
+            $Node = [PSNode]::ParseInput($Object)
+        }
+
+        it 'All' {
+            $ItemNodes = $Node.LeafNodes
+            $ItemNodes.Count | Should -Be 16
+        }
+    }
+
     Context 'Get map child nodes' {
         BeforeAll {
             $Node = [PSNode]::ParseInput($Object)

--- a/WhatsNew.md
+++ b/WhatsNew.md
@@ -1,4 +1,14 @@
-## 2024-02-22 0.0.19 (iRon)
+## 2024-02-28 0.0.20 (iRon)
+  - Fixed
+    - `ConvertTo-Expression` adding `$Null` entries
+    - #50 Copy-ObjectGraph -ListAs Array gives error
+    - #51 Document (markdown) issue in: Copy-ObjectGraph.md (fixed `Get-MarkdownHelp`))
+
+  - Enhancements
+    - Improved .ChildNode and related properties by one-by-one collecting sub nodes
+    - #53 return a warning (rather than an error) when Get-ChildNode is a leaf node
+
+## 2024-02-26 0.0.19 (iRon)
   - Fixed
     - `ConvertTo-Expression` adding `$Null` entries
 


### PR DESCRIPTION
## 2024-02-28 0.0.20 (iRon)
  - Fixed
    - `ConvertTo-Expression` adding `$Null` entries
    - #50 Copy-ObjectGraph -ListAs Array gives error
    - #51 Document (markdown) issue in: Copy-ObjectGraph.md (fixed `Get-MarkdownHelp`))

  - Enhancements
    - Improved .ChildNode and related properties by one-by-one collecting sub nodes
    - #53 return a warning (rather than an error) when Get-ChildNode is a leaf node