### PR TITLE
Full implementation of `ConvertTo-Expression`

### DIFF
--- a/ObjectGraphTools.psd1
+++ b/ObjectGraphTools.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ObjectGraphTools.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.1.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Source/Classes/ObjectParser.ps1
+++ b/Source/Classes/ObjectParser.ps1
@@ -20,6 +20,318 @@ using namespace System.Collections.Generic
 using namespace System.Management.Automation
 using namespace System.Management.Automation.Language
 
+
+ #    _____                              _             ____        _ _     _
+ #   | ____|_  ___ __  _ __ ___  ___ ___(_) ___  _ __ | __ ) _   _(_) | __| | ___ _ __
+ #   |  _| \ \/ / '_ \| '__/ _ \/ __/ __| |/ _ \| '_ \|  _ \| | | | | |/ _` |/ _ \ '__|
+ #   | |___ >  <| |_) | | |  __/\__ \__ \ | (_) | | | | |_) | |_| | | | (_| |  __/ |
+ #   |_____/_/\_\ .__/|_|  \___||___/___/_|\___/|_| |_|____/ \__,_|_|_|\__,_|\___|_|
+ #              |_|
+
+
+Class PSExpression {
+    hidden static [String[]]$Parameters = 'LanguageMode', 'Explicit', 'FullTypeName', 'HighFidelity', 'Indent', 'ExpandSingleton'
+    hidden [PSLanguageMode]$LanguageMode = 'Restricted'
+    hidden [Int]$ExpandDepth = [Int]::MaxValue
+    hidden [Bool]$Explicit
+    hidden [Bool]$FullTypeName
+    hidden [bool]$HighFidelity
+    hidden [String]$Indent = '    '
+    hidden [Bool]$ExpandSingleton
+
+    hidden static [Dictionary[String,Bool]]$IsConstrainedType = [Dictionary[String,Bool]]::new()
+    hidden static [Dictionary[String,Bool]]$HasStringConstructor = [Dictionary[String,Bool]]::new()
+    hidden static $RoundTripProperty = @{
+        'Microsoft.Management.Infrastructure.CimInstance'                     = ''
+        'Microsoft.Management.Infrastructure.CimSession'                      = 'ComputerName'
+        'Microsoft.PowerShell.Commands.ModuleSpecification'                   = 'Name'
+        'System.DirectoryServices.DirectoryEntry'                             = 'Path'
+        'System.DirectoryServices.DirectorySearcher'                          = 'Filter'
+        'System.Globalization.CultureInfo'                                    = 'Name'
+        'System.Management.Automation.AliasAttribute'                         = 'AliasNames'
+        'System.Management.Automation.ArgumentCompleterAttribute'             = 'ScriptBlock.Ast'
+        'System.Management.Automation.CmdletBindingAttribute'                 = @{}
+        'System.Management.Automation.DscPropertyAttribute'                   = @{}
+        'System.Management.Automation.DscResourceAttribute'                   = @{}
+        'System.Management.Automation.OutputTypeAttribute'                    = 'Type'
+        'System.Management.Automation.ParameterAttribute'                     = @{}
+        'System.Management.Automation.PSDefaultValueAttribute'                = @{}
+        'System.Management.Automation.PSListModifier'                         = 'Replace'
+        'System.Management.Automation.PSReference'                            = 'Value'
+        'System.Management.Automation.PSTypeNameAttribute'                    = 'PSTypeName'
+        'System.Management.Automation.ScriptBlock'                            = 'Ast'
+        'System.Management.Automation.SemanticVersion'                        = ''
+        'System.Management.Automation.ValidateDriveAttribute'                 = @{}
+        'System.Management.Automation.ValidateUserDriveAttribute'             = @{}
+        'System.Management.Automation.ValidatePatternAttribute'               = 'RegexPattern'
+        'System.Management.Automation.ValidateScriptAttribute'                = 'ScriptBlock.Ast'
+        'System.Management.Automation.ValidateSetAttribute'                   = 'ValidValues'
+        'System.Management.ManagementClass'                                   = 'Path'
+        'System.Management.ManagementObject'                                  = 'Path'
+        'System.Management.ManagementObjectSearcher'                          = 'Query.QueryString'
+        'System.Net.IPAddress'                                                = 'IPAddressToString'
+        'System.Net.IPEndPoint'                                               = 'IPAddressToString', 'Port'
+        'System.Net.Mail.MailAddress'                                         = 'Address'
+        'System.Security.Cryptography.X509Certificates.X500DistinguishedName' = 'Name'
+        'System.Security.Cryptography.X509Certificates.X509Certificate'       = @{}
+        'System.Text.RegularExpressions.Regex'                                = ''
+        'System.Uri'                                                          = 'OriginalString'
+        'System.Version'                                                      = ''
+    }
+    hidden [System.Text.StringBuilder]$StringBuilder = [System.Text.StringBuilder]::new()
+    hidden [Int]$Offset = 0
+    hidden [Int]$LineNumber = 1
+
+    hidden static [Bool]IsConstrained([Type]$Type) { # https://stackoverflow.com/a/64806919/1701026
+        if ($Null -eq $Type) { Throw 'Constrained type can not be $Null' }
+        $FullName = $Type.FullName
+        if (-not [PSExpression]::IsConstrainedType.ContainsKey($FullName)) {
+            [PSExpression]::IsConstrainedType[$FullName] = try {
+                $ConstrainedSession = [PowerShell]::Create()
+                $ConstrainedSession.RunSpace.SessionStateProxy.LanguageMode = 'Constrained'
+                $ConstrainedSession.AddScript("[$FullName]0").Invoke().Count -ne 0 -or
+                $ConstrainedSession.Streams.Error[0].FullyQualifiedErrorId -ne 'ConversionSupportedOnlyToCoreTypes'
+            } catch { $False }
+        }
+        return [PSExpression]::IsConstrainedType[$FullName]
+    }
+
+    Static PSExpression () {
+        [PSExpression]::IsConstrainedType['System.Management.Automation.PSCustomObject'] = $True # https://github.com/PowerShell/PowerShell/issues/20767
+    }
+    # PSExpression () { }
+    PSExpression($Object) { $this.Serialize($Object) }
+    PSExpression($Object, [HashTable]$Parameters) {
+        foreach ($Name in $Parameters.get_Keys()) { # https://github.com/PowerShell/PowerShell/issues/13307
+            if ($Name -notin [PSExpression]::Parameters) { Throw "Unknown parameter: $Name." }
+            $this.GetType().GetProperty($Name).SetValue($this, $Parameters[$Name])
+        }
+        $this.Serialize($Object)
+    }
+    PSExpression(
+        $Object,
+        $LanguageMode    = 'Restricted',
+        $ExpandDepth     = [Int]::MaxValue,
+        $Explicit        = $False,
+        $FullTypeName    = $False,
+        $HighFidelity    = $False,
+        $ExpandSingleton = $False,
+        $Indent          = '    '
+    ) {
+        $this.LanguageMode    = $LanguageMode
+        $this.ExpandDepth     = $ExpandDepth
+        $this.Explicit        = $Explicit
+        $this.FullTypeName    = $FullTypeName
+        $this.HighFidelity    = $HighFidelity
+        $this.ExpandSingleton = $ExpandSingleton
+        $this.Indent          = $Indent
+        $this.Serialize($Object)
+    }
+
+    [String]Serialize($Object) {
+        if ($this.LanguageMode -eq 'NoLanguage') { Throw 'The language mode "NoLanguage" is not supported.' }
+        if (-not ('ConstrainedLanguage', 'FullLanguage' -eq $this.LanguageMode)) {
+            if ($this.FullTypeName) { Write-Warning 'The FullTypeName switch requires Constrained - or FullLanguage mode.' }
+            if ($this.Explicit)     { Write-Warning 'The Explicit switch requires Constrained - or FullLanguage mode.' }
+        }
+        if ($Object -is [PSNode]) { $Node = $Object }
+        else { $Node = [PSNode]::ParseInput($Object) }
+        $this.Iterate($Node)
+        return $this.StringBuilder.ToString()
+    }
+
+    hidden Iterate([PSNode]$Node) {
+        $Value = $Node.Value
+        if ($Null -eq $Value) {
+            $this.StringBuilder.Append('$Null')
+            return
+        }
+        $Type = $Node.ValueType
+        $TypeName = "$Type"
+        $TypeInitializer =
+            if ($Null -ne $Type -and (
+                $this.LanguageMode -eq 'Full' -or (
+                        $this.LanguageMode -eq 'Constrained' -and
+                        [PSExpression]::IsConstrained($Type) -and (
+                            $this.Explicit -or -not (
+                                $Type.IsPrimitive      -or
+                                $Value -is [String]    -or
+                                $Value -is [Object[]]  -or
+                                $Value -is [Hashtable]
+                            )
+                        )
+                    )
+                )
+                ) {
+                    if ($this.FullTypeName) {
+                        if ($Type.FullName -eq 'System.Management.Automation.PSCustomObject' ) { '[System.Management.Automation.PSObject]' } # https://github.com/PowerShell/PowerShell/issues/2295
+                        else { "[$($Type.FullName)]" }
+                    }
+                    elseif ($TypeName -eq 'System.Object[]') { "[array]" }
+                    elseif ($TypeName -eq 'System.Management.Automation.PSCustomObject') { "[PSCustomObject]" }
+                    else { "[$TypeName]" }
+                }
+        if ($TypeInitializer) { $this.StringBuilder.Append($TypeInitializer) }
+
+        if ($Node -is [PSLeafNode] -or (-not $this.HighFidelity -and [PSExpression]::RoundTripProperty.Contains($Node.ValueType.FullName))) {
+            $Convert = $Null
+            $Expression = Switch ($TypeName) {
+                adsi                   { $Value.Path }
+                adsisearcher           { $Value.Filter }
+                Alias                  { $Value.AliasNames; $Convert = '[String[]]'}
+                ArgumentCompleter      { $Value.ScriptBlock }
+                ArgumentCompletions    { $Value; $Convert = '[String[]]' }
+                char                   { "'$Value'" }
+                CimSession             { $Value.ComputerName }
+                cimtype                { "$Value" }
+                CmdletBinding          { @{} }
+                DateTime               { $Value.ToString('o') }
+                ExperimentAction       { "$Value" }
+                IPEndpoint             { ,@($Value.Address.Address, $Value.Port); $Convert = '::new' }
+                System.Object          { ,@(); $Convert = '::new' }
+                OutputType             { $Value.Type; $Convert = '[String[]]'}
+                pscredential           { ,@($Value.UserName, @("(""$($Value.Password | ConvertFrom-SecureString)""", '|', 'ConvertTo-SecureString)')); $Convert = '::new' }
+                pslistmodifier         { @{} }
+                PSTypeNameAttribute    { $Value.PSTypeName }
+                ref                    { $Value.Value } # [ref] is not recognized
+                securestring           { ,[string[]]("(""$($Value | ConvertFrom-SecureString)""", '|', 'ConvertTo-SecureString)') } ####
+                switch                 { $Value.IsPresent }
+                ValidateDrive          { ,@(); $Convert = '::new' }
+                ValidateNotNull        { ,@(); $Convert = '::new' }
+                ValidateNotNullOrEmpty { ,@(); $Convert = '::new' }
+                ValidatePattern        { $Value.RegexPattern }
+                ValidateScript         { $Value.ScriptBlock }
+                ValidateSet            { $Value.ValidValues; $Convert = '[String[]]' }
+                Void                   { $Null }
+                WildcardPattern        { $Value.ToWql().Replace('%', '*').Replace('_', '?').Replace('[*]', '%').Replace('[?]', '_') }
+                wmiclass               { $Value }
+                wmisearcher            { $Value.Query.QueryString }
+                X500DistinguishedName  { $Value.Name }
+                X509Certificate        { @{} }
+                # xml                    { [System.Xml.Linq.XDocument]::Parse($Value.OuterXml).ToString() }
+                default {
+                    if ($Null -eq $Value) { '$Null' }
+                    elseif ($Type.IsPrimitive) { $Value }
+                    elseif (-not $Type.GetConstructors()) { "$TypeName"; $Convert = '[Void]' }
+                    elseif ($Value -is [Attribute]) { $Null }
+                    elseif ($Type.GetMethod('ToString', [Type[]]@())) { $Value.ToString() }
+                    elseif ($Value -is [ComponentModel.Component]) { @{} }
+                    elseif ($Value -is [Collections.ICollection])  { ,$Value }
+                    else { $Value } # Handle compression
+
+                }
+            }
+
+            if ($Null -eq $Expression) {
+                if ($this.LanguageMode -eq 'Restricted') { $Expression = '$Null' } else { $Expression = '@{}' }
+            }
+            elseif ($Expression -is [bool]) {
+                $Expression = "`$$Value"
+            }
+            elseif ($Expression -is [ScriptBlock]) {
+                $Expression = "{$Expression}"
+            }
+            elseif ($Expression -is [HashTable]) {
+                $Expression = '@{}' ##### Consider ConvertTo-Expression
+            }
+            elseif ($Expression -is [String[]]) {
+                $Space = if ($this.ExpandDepth -ge 0) { ' ' }
+                $_ -Join $Space
+            }
+            elseif ($Expression -is [array]) {
+                $Space = if ($this.ExpandDepth -ge 0) { ' ' }
+                $Expression = '(' + ($Expression.foreach{
+                    if ($Null -eq $_)  { '$Null' }
+                    elseif ($_.GetType().IsPrimitive) { "$_" }
+                    elseif ($_ -is [Array]) { $_ -Join $Space }
+                    else { "'$_'" }
+                } -Join ",$Space") + ')'
+            }
+            elseif ($Type -and -not $Type.IsPrimitive) {
+                if ($Expression -isnot [String]) { $Expression = "$Expression" }
+                $Expression = if ($Expression.Contains("`n")) {
+                    "@'" + [Environment]::NewLine + "$Expression".Replace("'", "''") + [Environment]::NewLine + "'@"
+                }
+                else {
+                    "'" + "$Expression".Replace("'", "''") + "'"
+                }
+            }
+
+            if ($TypeInitializer) { $this.StringBuilder.Append($Convert) }
+
+            $this.StringBuilder.Append($Expression)
+        }
+        elseif ($Node -is [PSListNode]) {
+            $this.StringBuilder.Append('@(')
+            $this.Offset++
+            $StartLine = $this.LineNumber
+            $Index = 0
+            $ChildNodes = $Node.get_ChildNodes()
+            # $ExpandSingle = $this.ExpandSingleton -and -not ($ChildNodes.Count -eq 1 -and $ChildNodes[0] -is [PSLeafNode])
+            $ExpandSingle = $this.ExpandSingleton -or $ChildNodes.Count -gt 1 -or ($ChildNodes.Count -eq 1 -and $ChildNodes[0] -isnot [PSLeafNode])
+            $ChildNodes.foreach{
+                if ($Index++) {
+                    $this.StringBuilder.Append(',')
+                    $this.NewWord()
+                }
+                elseif ($ExpandSingle) { $this.NewWord('') }
+                $this.Iterate($_)
+            }
+            $this.Offset--
+            if ($this.LineNumber -gt $StartLine) { $this.NewWord('') }
+            $this.StringBuilder.Append(')')
+        }
+        else { # if ($Node -is [PSMapNode]) {
+            $this.StringBuilder.Append('@{')
+            $this.Offset++
+            $StartLine = $this.LineNumber
+            $Index = 0
+            $ChildNodes = $Node.get_ChildNodes()
+            $ExpandSingle = $this.ExpandSingleton -or $ChildNodes.Count -gt 1 -or $ChildNodes[0] -isnot [PSLeafNode]
+            $ChildNodes.foreach{
+                if ($Index++) {
+                    $Separator = if ($this.ExpandDepth -ge 0) { '; ' } else { ';' }
+                    $this.NewWord($Separator)
+                }
+                elseif ($ExpandSingle) { $this.NewWord() }
+                elseif ($this.ExpandDepth -ge 0) { $this.StringBuilder.Append(' ') }
+                $this.StringBuilder.Append($_.Name)
+                if ($this.ExpandDepth -ge 0) { $this.StringBuilder.Append(' = ') } else { $this.StringBuilder.Append('=') }
+                $this.Iterate($_)
+            }
+            $this.Offset--
+            if ($this.LineNumber -gt $StartLine) { $this.NewWord() } else { $this.StringBuilder.Append(' ') }
+            $this.StringBuilder.Append('}')
+        }
+    }
+
+    hidden NewWord() { $this.NewWord(' ') }
+    hidden NewWord([String]$Separator) {
+        if ($this.Offset -le $this.ExpandDepth) {
+            $this.StringBuilder.AppendLine()
+            for($i = $this.Offset; $i -gt 0; $i--) {
+                $this.StringBuilder.Append($this.Indent)
+            }
+            $this.LineNumber++
+        }
+        else {
+            $this.StringBuilder.Append($Separator)
+        }
+    }
+
+    hidden [String]Quote($Value) { return "'" + "$Value".Replace("'", "''") + "'" }
+
+    [String] ToString() {
+        return $this.StringBuilder.ToString()
+    }
+ }
+
+ #   __  __   _
+ #   \ \/ /__| |_ __
+ #    \  // _` | '_ \
+ #    /  \ (_| | | | |
+ #   /_/\_\__,_|_| |_|
+
 enum XdnType { Root; Ancestor; Index; Child; Descendant; Equals; Error = 99 }
 
 enum XdnColorName { Reset; Regular; Literal; WildCard; Operator; Error = 99 }
@@ -276,6 +588,12 @@ Class PSNodePath {
 
 }
 
+#     ____  ____  _   _           _
+#    |  _ \/ ___|| \ | | ___   __| | ___
+#    | |_) \___ \|  \| |/ _ \ / _` |/ _ \
+#    |  __/ ___) | |\  | (_) | (_| |  __/
+#    |_|   |____/|_| \_|\___/ \__,_|\___|
+
 Class PSNode {
     hidden static PSNode() { Use-ClassAccessors }
 
@@ -289,7 +607,7 @@ Class PSNode {
     [PSNode]$RootNode = $this
     hidden [PSNodePath]$_Path
     hidden [String]$_PathName
-    hidden [Bool]$WarnedMaxDepth            # Warn ones per item branch
+    hidden [DateTime]$MaxDepthWarningTime            # Warn ones per item branch
 
     hidden [object] get_Value() {
         return ,$this._Value
@@ -330,11 +648,16 @@ Class PSNode {
     }
 
     hidden static [String]GetPSNodeType($Object) {
-            if ($Object -is [Management.Automation.PSCustomObject]) { return 'PSObjectNode' }
-        elseif ($Object -is [ComponentModel.Component])             { return 'PSObjectNode' }
-        elseif ($Object -is [Collections.IDictionary])              { return 'PSDictionaryNode' }
-        elseif ($Object -is [Collections.ICollection])              { return 'PSListNode' }
-        else                                                        { return 'PSLeafNode' }
+        if ($Null -eq $Object)                                                                { return 'PSLeafNode' }
+        elseif ($Object -is [Management.Automation.PSCustomObject])                           { return 'PSObjectNode' }
+        elseif ($Object -is [Collections.IDictionary])                                        { return 'PSDictionaryNode' }
+        elseif ($Object -is [Specialized.StringDictionary])                                   { return 'PSDictionaryNode' }
+        elseif ($Object -is [Collections.ICollection])                                        { return 'PSListNode' }
+        elseif ($Object -is [ValueType])                                                      { return 'PSLeafNode' }
+        elseif ($Object -is [String])                                                         { return 'PSLeafNode' }
+        elseif ($Object -is [ScriptBlock])                                                    { return 'PSLeafNode' }
+        elseif ($Object.PSObject.Properties.where{ $_.Value -isnot [Reflection.MemberInfo] }) { return 'PSObjectNode' }
+        else                                                                                  { return 'PSLeafNode' }
     }
 
     static [PSNode] ParseInput($Object, $MaxDepth) {
@@ -455,6 +778,8 @@ Class PSNode {
         if ($NodeTable.Count -eq 1) { return $NodeTable[$NodeTable.Keys] }
         else                        { return [PSNode[]]$NodeTable.Values }
     }
+
+    [String] ToExpression() { return [PSExpression]$this }
 }
 
 Class PSLeafNode : PSNode {
@@ -472,10 +797,16 @@ Class PSCollectionNode : PSNode {
     hidden static PSCollectionNode() { Use-ClassAccessors }
 
     hidden [bool]MaxDepthReached() {
+        # Check whether the max depth has been reached.
+        # Warn if it has, but suppress the warning if
+        # it took less then 5 seconds since the last
+        # time it reached the max depth.
         $MaxDepthReached = $this.Depth -ge $this.RootNode._MaxDepth
-        if ($MaxDepthReached -and -not $this.WarnedMaxDepth) {
-            Write-Warning "$($this.Path) reached the maximum depth of $($this.RootNode._MaxDepth)."
-            $this.WarnedMaxDepth = $True
+        if ($MaxDepthReached) {
+            if (([Datetime]::Now - $this.RootNode.MaxDepthWarningTime).TotalSeconds -gt 5) {
+                Write-Warning "$($this.Path) reached the maximum depth of $($this.RootNode._MaxDepth)."
+            }
+            $this.RootNode.MaxDepthWarningTime = [Datetime]::Now
         }
         return $MaxDepthReached
     }
@@ -699,6 +1030,7 @@ Class PSObjectNode : PSMapNode {
     hidden CollectChildNodes($NodeList, [Int]$Levels, [PSNodeOrigin]$NodeOrigin, [Bool]$Leaf) {
         if (-not $this.MaxDepthReached()) {
             foreach($Property in $this._Value.PSObject.Properties) {
+                if ($Property.Value -is [Reflection.MemberInfo]) { continue }
                 $Node = $this.Append($Property.Value)
                 $Node._Name = $Property.Name
                 if ($NodeOrigin -in 0, 'Map' -and (-not $Leaf -or $Node -is [PSLeafNode])) { $NodeList.Add($Node) }
@@ -722,3 +1054,5 @@ Class PSObjectNode : PSMapNode {
 }
 
 Update-TypeData -TypeName PSNode -DefaultDisplayPropertySet Path, Name, Depth, Value -Force
+
+

--- a/Tests/ConvertTo-Expression.Tests.ps1
+++ b/Tests/ConvertTo-Expression.Tests.ps1
@@ -6,32 +6,14 @@ using module ..\..\ObjectGraphTools
 [Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'ObjectGraph', Justification = 'False positive')]
 param()
 
+# $PesterPreference = [PesterConfiguration]::Default
+# $PesterPreference.Should.ErrorAction = 'Stop'
+
 Describe 'ConvertTo-Expression' {
 
     BeforeAll {
 
         Set-StrictMode -Version Latest
-
-        $Object = @{
-            Comment = 'Sample ObjectGraph'
-            Data = @(
-                @{
-                    Index = 1
-                    Name = 'One'
-                    Comment = 'First item'
-                }
-                @{
-                    Index = 2
-                    Name = 'Two'
-                    Comment = 'Second item'
-                }
-                @{
-                    Index = 3
-                    Name = 'Three'
-                    Comment = 'Third item'
-                }
-            )
-        }
     }
 
     Context 'Existence Check' {
@@ -40,10 +22,2246 @@ Describe 'ConvertTo-Expression' {
             ConvertTo-Expression -? | Out-String -Stream | Should -Contain SYNOPSIS
         }
     }
+
+    Context 'Constrained values' {
+        It 'adsi' {
+            $Object = Invoke-Expression "[adsi]'WinNT://WORKGROUP/./Administrator'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'WinNT://WORKGROUP/./Administrator'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[adsi]'WinNT://WORKGROUP/./Administrator'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[adsi]'WinNT://WORKGROUP/./Administrator'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[adsi]'WinNT://WORKGROUP/./Administrator'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[adsi]'WinNT://WORKGROUP/./Administrator'"
+        }
+
+        It 'adsisearcher' {
+            $Object = Invoke-Expression "[adsisearcher]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[adsisearcher]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[adsisearcher]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[adsisearcher]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[adsisearcher]'0123'"
+        }
+
+        It 'Alias' {
+            $Object = Invoke-Expression "[Alias][String[]]'Example'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[Alias][String[]]'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[Alias][String[]]'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[Alias][String[]]'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[Alias][String[]]'Example'"
+        }
+
+        It 'AllowEmptyCollection' {
+            $Object = Invoke-Expression "[AllowEmptyCollection]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[AllowEmptyCollection]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[AllowEmptyCollection]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[AllowEmptyCollection]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[AllowEmptyCollection]@{}"
+        }
+
+        It 'AllowEmptyString' {
+            $Object = Invoke-Expression "[AllowEmptyString]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[AllowEmptyString]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[AllowEmptyString]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[AllowEmptyString]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[AllowEmptyString]@{}"
+        }
+
+        It 'AllowNull' {
+            $Object = Invoke-Expression "[AllowNull]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[AllowNull]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[AllowNull]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[AllowNull]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[AllowNull]@{}"
+        }
+
+        It 'ArgumentCompleter' {
+            $Object = Invoke-Expression "[ArgumentCompleter]{'Example'}"
+            ConvertTo-Expression -InputObject $Object | Should -Be "{'Example'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ArgumentCompleter]{'Example'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ArgumentCompleter]{'Example'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ArgumentCompleter]{'Example'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ArgumentCompleter]{'Example'}"
+        }
+
+        It 'ArgumentCompletions' -Skip:(-not ('ArgumentCompletions' -as [Type])) {
+            $Object = Invoke-Expression "[ArgumentCompletions][String[]]'System.Management.Automation.ArgumentCompletionsAttribute'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'System.Management.Automation.ArgumentCompletionsAttribute'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ArgumentCompletions][String[]]'System.Management.Automation.ArgumentCompletionsAttribute'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ArgumentCompletions][String[]]'System.Management.Automation.ArgumentCompletionsAttribute'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ArgumentCompletions][String[]]'System.Management.Automation.ArgumentCompletionsAttribute'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ArgumentCompletions][String[]]'System.Management.Automation.ArgumentCompletionsAttribute'"
+        }
+
+        It 'bigint' {
+            $Object = Invoke-Expression "[bigint]'1234567890'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'1234567890'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[bigint]'1234567890'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[bigint]'1234567890'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[bigint]'1234567890'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[bigint]'1234567890'"
+        }
+
+        It 'bool' {
+            $Object = Invoke-Expression '[bool]$True'
+            ConvertTo-Expression -InputObject $Object | Should -Be '$True'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be '$True'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be '[bool]$True'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be '[bool]$True'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be '[bool]$True'
+        }
+
+        It 'byte' {
+            $Object = Invoke-Expression "[byte]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[byte]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[byte]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[byte]123"
+        }
+
+        It 'char' {
+            $Object = Invoke-Expression "[char]'a'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'a'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "'a'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[char]'a'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[char]'a'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[char]'a'"
+        }
+
+        It 'ciminstance' {
+            $Object = Invoke-Expression "[ciminstance]'Example'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ciminstance]'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ciminstance]'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ciminstance]'Example'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ciminstance]'Example'"
+        }
+
+        It 'CimSession' {
+            $Object = Invoke-Expression "[CimSession]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[CimSession]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[CimSession]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[CimSession]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[CimSession]'0123'"
+        }
+
+        It 'cimtype' {
+            $Object = Invoke-Expression "[cimtype]'Boolean'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'Boolean'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[cimtype]'Boolean'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[cimtype]'Boolean'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[cimtype]'Boolean'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[cimtype]'Boolean'"
+        }
+
+        It 'CmdletBinding' {
+            $Object = Invoke-Expression "[CmdletBinding]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be "@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[CmdletBinding]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[CmdletBinding]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[CmdletBinding]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[CmdletBinding]@{}"
+        }
+
+        It 'cultureinfo' {
+            $Object = Invoke-Expression "[cultureinfo]'en-US'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'en-US'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[cultureinfo]'en-US'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[cultureinfo]'en-US'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[cultureinfo]'en-US'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[cultureinfo]'en-US'"
+        }
+
+        It 'datetime' {
+            $Object = Invoke-Expression "[datetime]'1963-10-07T17:56:53.8139055'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'1963-10-07T17:56:53.8139055'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[datetime]'1963-10-07T17:56:53.8139055'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[datetime]'1963-10-07T17:56:53.8139055'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[datetime]'1963-10-07T17:56:53.8139055'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[datetime]'1963-10-07T17:56:53.8139055'"
+        }
+
+        It 'decimal' {
+            $Object = Invoke-Expression "[decimal]'0.123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0.123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[decimal]'0.123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[decimal]'0.123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[decimal]'0.123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[decimal]'0.123'"
+        }
+
+        It 'double' {
+            $Object = Invoke-Expression "[double]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[double]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[double]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[double]123"
+        }
+
+        It 'DscLocalConfigurationManager' {
+            $Object = Invoke-Expression "[DscLocalConfigurationManager]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[DscLocalConfigurationManager]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[DscLocalConfigurationManager]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[DscLocalConfigurationManager]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[DscLocalConfigurationManager]@{}"
+        }
+
+        It 'DscProperty' {
+            $Object = Invoke-Expression "[DscProperty]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[DscProperty]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[DscProperty]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[DscProperty]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[DscProperty]@{}"
+        }
+
+        It 'DscResource' {
+            $Object = Invoke-Expression "[DscResource]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[DscResource]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[DscResource]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[DscResource]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[DscResource]@{}"
+        }
+
+        It 'ExperimentAction' -Skip:(-not ('ExperimentAction' -as [Type])) {
+            $Object = Invoke-Expression "[ExperimentAction]'None'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'None'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ExperimentAction]'None'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ExperimentAction]'None'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ExperimentAction]'None'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ExperimentAction]'None'"
+        }
+
+        It 'float' {
+            $Object = Invoke-Expression "[float]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[float]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[float]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[float]123"
+        }
+
+        It 'guid' {
+            $Object = Invoke-Expression "[guid]'19631007-bd7b-41cc-a6c7-bb1772d6ef46'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'19631007-bd7b-41cc-a6c7-bb1772d6ef46'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[guid]'19631007-bd7b-41cc-a6c7-bb1772d6ef46'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[guid]'19631007-bd7b-41cc-a6c7-bb1772d6ef46'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[guid]'19631007-bd7b-41cc-a6c7-bb1772d6ef46'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[guid]'19631007-bd7b-41cc-a6c7-bb1772d6ef46'"
+        }
+
+        It 'int' {
+            $Object = Invoke-Expression "[int]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[int]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[int]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[int]123"
+        }
+
+        It 'short' -Skip:(-not ('short' -as [Type])) {
+            $Object = Invoke-Expression "[short]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[short]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[short]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[short]123"
+        }
+
+        It 'long' {
+            $Object = Invoke-Expression "[long]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[long]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[long]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[long]123"
+        }
+
+        It 'ipaddress' {
+            $Object = Invoke-Expression "[ipaddress]'198.168.1.1'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'198.168.1.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ipaddress]'198.168.1.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ipaddress]'198.168.1.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ipaddress]'198.168.1.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ipaddress]'198.168.1.1'"
+        }
+
+        It 'IPEndpoint' {
+            $Object = Invoke-Expression "[IPEndpoint]::new(16885958, 123)"
+            ConvertTo-Expression -InputObject $Object | Should -Be "(16885958, 123)"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[IPEndpoint]::new(16885958, 123)"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[IPEndpoint]::new(16885958, 123)"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[IPEndpoint]::new(16885958, 123)"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[IPEndpoint]::new(16885958, 123)"
+        }
+
+        It 'mailaddress' {
+            $Object = Invoke-Expression "[mailaddress]'iron@contoso.com'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'iron@contoso.com'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[mailaddress]'iron@contoso.com'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[mailaddress]'iron@contoso.com'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[mailaddress]'iron@contoso.com'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[mailaddress]'iron@contoso.com'"
+        }
+
+        It 'Microsoft.PowerShell.Commands.ModuleSpecification' {
+            $Object = Invoke-Expression "[Microsoft.PowerShell.Commands.ModuleSpecification]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[Microsoft.PowerShell.Commands.ModuleSpecification]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[Microsoft.PowerShell.Commands.ModuleSpecification]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[Microsoft.PowerShell.Commands.ModuleSpecification]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[Microsoft.PowerShell.Commands.ModuleSpecification]'0123'"
+        }
+
+        It 'NoRunspaceAffinity' -Skip:(-not ('NoRunspaceAffinity' -as [Type])) {
+            $Object = Invoke-Expression "[NoRunspaceAffinity]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[NoRunspaceAffinity]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[NoRunspaceAffinity]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[NoRunspaceAffinity]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[NoRunspaceAffinity]@{}"
+        }
+
+        It 'System.Object' {
+            $Object = Invoke-Expression "[System.Object]::new()"
+            ConvertTo-Expression -InputObject $Object | Should -Be "()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[System.Object]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[System.Object]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[System.Object]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[System.Object]::new()"
+        }
+
+        It 'OutputType' {
+            $Object = Invoke-Expression "[OutputType][String[]]'bool'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'bool'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[OutputType][String[]]'bool'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[OutputType][String[]]'bool'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[OutputType][String[]]'bool'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[OutputType][String[]]'bool'"
+        }
+
+        It 'Parameter' {
+            $Object = Invoke-Expression "[Parameter]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[Parameter]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[Parameter]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[Parameter]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[Parameter]@{}"
+        }
+
+        It 'PhysicalAddress' {
+            $Object = Invoke-Expression "[PhysicalAddress]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[PhysicalAddress]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[PhysicalAddress]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[PhysicalAddress]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[PhysicalAddress]'0123'"
+        }
+
+        It 'PSDefaultValue' {
+            $Object = Invoke-Expression "[PSDefaultValue]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[PSDefaultValue]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[PSDefaultValue]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[PSDefaultValue]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[PSDefaultValue]@{}"
+        }
+
+        It 'pslistmodifier' {
+            $Object = Invoke-Expression "[pslistmodifier]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be "@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[pslistmodifier]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[pslistmodifier]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[pslistmodifier]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[pslistmodifier]@{}"
+        }
+
+        It 'PSTypeNameAttribute' {
+            $Object = Invoke-Expression "[PSTypeNameAttribute]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[PSTypeNameAttribute]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[PSTypeNameAttribute]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[PSTypeNameAttribute]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[PSTypeNameAttribute]'0123'"
+        }
+
+        It 'regex' {
+            $Object = Invoke-Expression "[regex]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[regex]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[regex]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[regex]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[regex]'0123'"
+        }
+
+        It 'sbyte' {
+            $Object = Invoke-Expression "[sbyte]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[sbyte]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[sbyte]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[sbyte]123"
+        }
+
+        It 'semver' -Skip:(-not ('semver' -as [Type])) {
+            $Object = Invoke-Expression "[semver]'1.2.0-a.1'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'1.2.0-a.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[semver]'1.2.0-a.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[semver]'1.2.0-a.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[semver]'1.2.0-a.1'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[semver]'1.2.0-a.1'"
+        }
+
+        It 'string' {
+            $Object = Invoke-Expression "[string]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[string]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[string]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[string]'0123'"
+        }
+
+        It 'SupportsWildcards' {
+            $Object = Invoke-Expression "[SupportsWildcards]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[SupportsWildcards]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[SupportsWildcards]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[SupportsWildcards]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[SupportsWildcards]@{}"
+        }
+
+        It 'timespan' {
+            $Object = Invoke-Expression "[timespan]'1.02:03:04.0050000'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'1.02:03:04.0050000'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[timespan]'1.02:03:04.0050000'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[timespan]'1.02:03:04.0050000'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[timespan]'1.02:03:04.0050000'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[timespan]'1.02:03:04.0050000'"
+        }
+
+        It 'ushort' -Skip:(-not ('ushort' -as [Type])) {
+            $Object = Invoke-Expression "[ushort]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ushort]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ushort]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ushort]123"
+        }
+
+        It 'uint' -Skip:(-not ('uint' -as [Type])) {
+            $Object = Invoke-Expression "[uint]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[uint]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[uint]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[uint]123"
+        }
+
+        It 'ulong' -Skip:(-not ('ulong' -as [Type])) {
+            $Object = Invoke-Expression "[ulong]123"
+            ConvertTo-Expression -InputObject $Object | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ulong]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ulong]123"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ulong]123"
+        }
+
+        It 'uri' {
+            $Object = Invoke-Expression "[uri]'0123'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[uri]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[uri]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[uri]'0123'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[uri]'0123'"
+        }
+
+        It 'ValidateDrive' {
+            $Object = Invoke-Expression "[ValidateDrive]::new()"
+            ConvertTo-Expression -InputObject $Object | Should -Be "()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateDrive]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateDrive]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateDrive]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateDrive]::new()"
+        }
+
+        It 'ValidateNotNull' {
+            $Object = Invoke-Expression "[ValidateNotNull]::new()"
+            ConvertTo-Expression -InputObject $Object | Should -Be "()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateNotNull]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateNotNull]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateNotNull]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateNotNull]::new()"
+        }
+
+        It 'ValidateNotNullOrEmpty' {
+            $Object = Invoke-Expression "[ValidateNotNullOrEmpty]::new()"
+            ConvertTo-Expression -InputObject $Object | Should -Be "()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateNotNullOrEmpty]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateNotNullOrEmpty]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateNotNullOrEmpty]::new()"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateNotNullOrEmpty]::new()"
+        }
+
+        It 'ValidateNotNullOrWhiteSpace' -Skip:(-not ('ValidateNotNullOrWhiteSpace' -as [Type])) {
+            $Object = Invoke-Expression "[ValidateNotNullOrWhiteSpace]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateNotNullOrWhiteSpace]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateNotNullOrWhiteSpace]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateNotNullOrWhiteSpace]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateNotNullOrWhiteSpace]@{}"
+        }
+
+        It 'ValidatePattern' {
+            $Object = Invoke-Expression "[ValidatePattern]'Pattern'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'Pattern'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidatePattern]'Pattern'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidatePattern]'Pattern'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidatePattern]'Pattern'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidatePattern]'Pattern'"
+        }
+
+        It 'ValidateScript' {
+            $Object = Invoke-Expression "[ValidateScript]{'Validate'}"
+            ConvertTo-Expression -InputObject $Object | Should -Be "{'Validate'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateScript]{'Validate'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateScript]{'Validate'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateScript]{'Validate'}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateScript]{'Validate'}"
+        }
+
+        It 'ValidateSet' {
+            $Object = Invoke-Expression "[ValidateSet][String[]]('Value1', 'Value2')"
+            ConvertTo-Expression -InputObject $Object | Should -Be "('Value1', 'Value2')"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateSet][String[]]('Value1', 'Value2')"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateSet][String[]]('Value1', 'Value2')"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateSet][String[]]('Value1', 'Value2')"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateSet][String[]]('Value1', 'Value2')"
+        }
+
+        It 'ValidateTrustedData' {
+            $Object = Invoke-Expression "[ValidateTrustedData]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateTrustedData]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateTrustedData]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateTrustedData]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateTrustedData]@{}"
+        }
+
+        It 'ValidateUserDrive' {
+            $Object = Invoke-Expression "[ValidateUserDrive]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be '$Null'
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[ValidateUserDrive]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[ValidateUserDrive]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[ValidateUserDrive]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[ValidateUserDrive]@{}"
+        }
+
+        It 'version' {
+            $Object = Invoke-Expression "[version]'0.1.2.3'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'0.1.2.3'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[version]'0.1.2.3'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[version]'0.1.2.3'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[version]'0.1.2.3'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[version]'0.1.2.3'"
+        }
+
+        It 'WildcardPattern' {
+            $Object = Invoke-Expression "[WildcardPattern]'_T?e%s*t'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'_T?e%s*t'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[WildcardPattern]'_T?e%s*t'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[WildcardPattern]'_T?e%s*t'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[WildcardPattern]'_T?e%s*t'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[WildcardPattern]'_T?e%s*t'"
+        }
+
+        It 'wmi' {
+            $Object = Invoke-Expression "[wmi]''"
+            ConvertTo-Expression -InputObject $Object | Should -Be "''"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[wmi]''"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[wmi]''"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[wmi]''"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[wmi]''"
+        }
+
+        It 'wmiclass' {
+            $Object = Invoke-Expression "[wmiclass]'\\$($Env:ComputerName)\ROOT\Cimv2:Win32_BIOS'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'\\$($Env:ComputerName)\ROOT\Cimv2:Win32_BIOS'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[wmiclass]'\\$($Env:ComputerName)\ROOT\Cimv2:Win32_BIOS'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[wmiclass]'\\$($Env:ComputerName)\ROOT\Cimv2:Win32_BIOS'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[wmiclass]'\\$($Env:ComputerName)\ROOT\Cimv2:Win32_BIOS'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[wmiclass]'\\$($Env:ComputerName)\ROOT\Cimv2:Win32_BIOS'"
+        }
+
+        It 'wmisearcher' {
+            $Object = Invoke-Expression "[wmisearcher]'QueryString'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'QueryString'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[wmisearcher]'QueryString'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[wmisearcher]'QueryString'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[wmisearcher]'QueryString'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[wmisearcher]'QueryString'"
+        }
+
+        It 'X500DistinguishedName' {
+            $Object = Invoke-Expression "[X500DistinguishedName]'CN=123,OID.0.9.2342.19200300.100.1.1=321'"
+            ConvertTo-Expression -InputObject $Object | Should -Be "'CN=123,OID.0.9.2342.19200300.100.1.1=321'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[X500DistinguishedName]'CN=123,OID.0.9.2342.19200300.100.1.1=321'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[X500DistinguishedName]'CN=123,OID.0.9.2342.19200300.100.1.1=321'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[X500DistinguishedName]'CN=123,OID.0.9.2342.19200300.100.1.1=321'"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[X500DistinguishedName]'CN=123,OID.0.9.2342.19200300.100.1.1=321'"
+        }
+
+        It 'X509Certificate' {
+            $Object = Invoke-Expression "[X509Certificate]@{}"
+            ConvertTo-Expression -InputObject $Object | Should -Be "@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[X509Certificate]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[X509Certificate]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[X509Certificate]@{}"
+            ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[X509Certificate]@{}"
+        }
+
+#         It 'xml' {
+#             $Object = Invoke-Expression "[xml]@'
+# <book>
+#   <name>A Song of Ice and Fire</name>
+#   <author>George R. R. Martin</author>
+#   <language>English</language>
+#   <genre>Epic fantasy</genre>
+# </book>
+# '@"
+#             ConvertTo-Expression -InputObject $Object | Should -Be "@'
+# <book>
+#   <name>A Song of Ice and Fire</name>
+#   <author>George R. R. Martin</author>
+#   <language>English</language>
+#   <genre>Epic fantasy</genre>
+# </book>
+# '@"
+#             ConvertTo-Expression -InputObject $Object -LanguageMode Constrained | Should -Be "[xml]@'
+# <book>
+#   <name>A Song of Ice and Fire</name>
+#   <author>George R. R. Martin</author>
+#   <language>English</language>
+#   <genre>Epic fantasy</genre>
+# </book>
+# '@"
+#             ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit | Should -Be "[xml]@'
+# <book>
+#   <name>A Song of Ice and Fire</name>
+#   <author>George R. R. Martin</author>
+#   <language>English</language>
+#   <genre>Epic fantasy</genre>
+# </book>
+# '@"
+#             ConvertTo-Expression -InputObject $Object -LanguageMode Full | Should -Be "[xml]@'
+# <book>
+#   <name>A Song of Ice and Fire</name>
+#   <author>George R. R. Martin</author>
+#   <language>English</language>
+#   <genre>Epic fantasy</genre>
+# </book>
+# '@"
+#             ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit | Should -Be "[xml]@'
+# <book>
+#   <name>A Song of Ice and Fire</name>
+#   <author>George R. R. Martin</author>
+#   <language>English</language>
+#   <genre>Epic fantasy</genre>
+# </book>
+# '@"
+        # }
+
+    }
+
+    Context 'Formatting' {
+        BeforeAll {
+            $Object = [PSCustomObject]@{
+                first_name = 'John'
+                last_name = 'Smith'
+                is_alive = $True
+                age = 27
+                address = [PSCustomObject]@{
+                    street_address = '21 2nd Street'
+                    city = 'New York'
+                    state = 'NY'
+                    postal_code = '10021-3100'
+                }
+                phone_numbers =[PSCustomObject] @(
+                    @{
+                        type = 'home'
+                        number = '212 555-1234'
+                    },
+                    @{
+                        type = 'office'
+                        number = '646 555-4567'
+                    }
+                )
+                children = @('Catherine')
+                spouse = $Null
+            }
+        }
+
+        It 'ConvertTo-Expression (Default)' {
+            $Expression = ConvertTo-Expression -InputObject $Object
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = @{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{
+            number = '212 555-1234'
+            type = 'home'
+        },
+        @{
+            number = '646 555-4567'
+            type = 'office'
+        }
+    )
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = @{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{
+            number = '212 555-1234'
+            type = 'home'
+        },
+        @{
+            number = '646 555-4567'
+            type = 'office'
+        }
+    )
+    children = @(
+        'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = @{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{ number = '212 555-1234'; type = 'home' },
+        @{ number = '646 555-4567'; type = 'office' }
+    )
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandSingleton -ExpandDepth 2' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandSingleton -ExpandDepth 2
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = @{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{ number = '212 555-1234'; type = 'home' },
+        @{ number = '646 555-4567'; type = 'office' }
+    )
+    children = @(
+        'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = @{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }
+    phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' })
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandSingleton -ExpandDepth 1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandSingleton -ExpandDepth 1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = @{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }
+    phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' })
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{ first_name = 'John'; last_name = 'Smith'; is_alive = $True; age = 27; address = @{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }; phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' }); children = @('Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandSingleton -ExpandDepth 0' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandSingleton -ExpandDepth 0
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{ first_name = 'John'; last_name = 'Smith'; is_alive = $True; age = 27; address = @{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }; phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' }); children = @('Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234';type='home' }, @{ number='646 555-4567';type='office' });children=@('Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandSingleton -ExpandDepth -1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandSingleton -ExpandDepth -1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234';type='home' }, @{ number='646 555-4567';type='office' });children=@('Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [PSCustomObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{
+            number = '212 555-1234'
+            type = 'home'
+        },
+        @{
+            number = '646 555-4567'
+            type = 'office'
+        }
+    )
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{
+            number = '212 555-1234'
+            type = 'home'
+        },
+        @{
+            number = '646 555-4567'
+            type = 'office'
+        }
+    )
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [PSCustomObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{
+            number = '212 555-1234'
+            type = 'home'
+        },
+        @{
+            number = '646 555-4567'
+            type = 'office'
+        }
+    )
+    children = @(
+        'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{
+            number = '212 555-1234'
+            type = 'home'
+        },
+        @{
+            number = '646 555-4567'
+            type = 'office'
+        }
+    )
+    children = @(
+        'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -ExpandDepth 2' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandDepth 2
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [PSCustomObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{ number = '212 555-1234'; type = 'home' },
+        @{ number = '646 555-4567'; type = 'office' }
+    )
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Constrained -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Constrained -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{ number = '212 555-1234'; type = 'home' },
+        @{ number = '646 555-4567'; type = 'office' }
+    )
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [PSCustomObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{ number = '212 555-1234'; type = 'home' },
+        @{ number = '646 555-4567'; type = 'office' }
+    )
+    children = @(
+        'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = '21 2nd Street'
+        city = 'New York'
+        state = 'NY'
+        postal_code = '10021-3100'
+    }
+    phone_numbers = @(
+        @{ number = '212 555-1234'; type = 'home' },
+        @{ number = '646 555-4567'; type = 'office' }
+    )
+    children = @(
+        'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -ExpandDepth 1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandDepth 1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [PSCustomObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }
+    phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' })
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Constrained -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Constrained -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [System.Management.Automation.PSObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }
+    phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' })
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [PSCustomObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }
+    phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' })
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = 'John'
+    last_name = 'Smith'
+    is_alive = $True
+    age = 27
+    address = [System.Management.Automation.PSObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }
+    phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' })
+    children = @('Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -ExpandDepth 0' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandDepth 0
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = 'John'; last_name = 'Smith'; is_alive = $True; age = 27; address = [PSCustomObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }; phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' }); children = @('Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Constrained -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Constrained -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = 'John'; last_name = 'Smith'; is_alive = $True; age = 27; address = [System.Management.Automation.PSObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }; phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' }); children = @('Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = 'John'; last_name = 'Smith'; is_alive = $True; age = 27; address = [PSCustomObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }; phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' }); children = @('Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = 'John'; last_name = 'Smith'; is_alive = $True; age = 27; address = [System.Management.Automation.PSObject]@{ street_address = '21 2nd Street'; city = 'New York'; state = 'NY'; postal_code = '10021-3100' }; phone_numbers = @(@{ number = '212 555-1234'; type = 'home' }, @{ number = '646 555-4567'; type = 'office' }); children = @('Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -ExpandDepth -1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandDepth -1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234';type='home' }, @{ number='646 555-4567';type='office' });children=@('Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234';type='home' }, @{ number='646 555-4567';type='office' });children=@('Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234';type='home' }, @{ number='646 555-4567';type='office' });children=@('Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234';type='home' }, @{ number='646 555-4567';type='office' });children=@('Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{
+            number = [string]'212 555-1234'
+            type = [string]'home'
+        },
+        [hashtable]@{
+            number = [string]'646 555-4567'
+            type = [string]'office'
+        }
+    )
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{
+            number = [System.String]'212 555-1234'
+            type = [System.String]'home'
+        },
+        [System.Collections.Hashtable]@{
+            number = [System.String]'646 555-4567'
+            type = [System.String]'office'
+        }
+    )
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{
+            number = [string]'212 555-1234'
+            type = [string]'home'
+        },
+        [hashtable]@{
+            number = [string]'646 555-4567'
+            type = [string]'office'
+        }
+    )
+    children = [array]@(
+        [string]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{
+            number = [System.String]'212 555-1234'
+            type = [System.String]'home'
+        },
+        [System.Collections.Hashtable]@{
+            number = [System.String]'646 555-4567'
+            type = [System.String]'office'
+        }
+    )
+    children = [System.Object[]]@(
+        [System.String]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' },
+        [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }
+    )
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 2 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 2 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' },
+        [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }
+    )
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' },
+        [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }
+    )
+    children = [array]@(
+        [string]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 2 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' },
+        [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }
+    )
+    children = [System.Object[]]@(
+        [System.String]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }
+    phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' })
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 1 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 1 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }
+    phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' })
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }
+    phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' })
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 1 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }
+    phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' })
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = [string]'John'; last_name = [string]'Smith'; is_alive = [bool]$True; age = [int]27; address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }; phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }); children = [array]@([string]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 0 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 0 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = [System.String]'John'; last_name = [System.String]'Smith'; is_alive = [System.Boolean]$True; age = [System.Int32]27; address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }; phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }); children = [System.Object[]]@([System.String]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = [string]'John'; last_name = [string]'Smith'; is_alive = [bool]$True; age = [int]27; address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }; phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }); children = [array]@([string]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 0 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = [System.String]'John'; last_name = [System.String]'Smith'; is_alive = [System.Boolean]$True; age = [System.Int32]27; address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }; phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }); children = [System.Object[]]@([System.String]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234';type=[string]'home' }, [hashtable]@{ number=[string]'646 555-4567';type=[string]'office' });children=[array]@([string]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234';type=[System.String]'home' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567';type=[System.String]'office' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234';type=[string]'home' }, [hashtable]@{ number=[string]'646 555-4567';type=[string]'office' });children=[array]@([string]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234';type=[System.String]'home' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567';type=[System.String]'office' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{
+            number = [string]'212 555-1234'
+            type = [string]'home'
+        },
+        [hashtable]@{
+            number = [string]'646 555-4567'
+            type = [string]'office'
+        }
+    )
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{
+            number = [System.String]'212 555-1234'
+            type = [System.String]'home'
+        },
+        [System.Collections.Hashtable]@{
+            number = [System.String]'646 555-4567'
+            type = [System.String]'office'
+        }
+    )
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{
+            number = [string]'212 555-1234'
+            type = [string]'home'
+        },
+        [hashtable]@{
+            number = [string]'646 555-4567'
+            type = [string]'office'
+        }
+    )
+    children = [array]@(
+        [string]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{
+            number = [System.String]'212 555-1234'
+            type = [System.String]'home'
+        },
+        [System.Collections.Hashtable]@{
+            number = [System.String]'646 555-4567'
+            type = [System.String]'office'
+        }
+    )
+    children = [System.Object[]]@(
+        [System.String]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -ExpandDepth 2' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandDepth 2
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' },
+        [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }
+    )
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Full -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Full -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' },
+        [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }
+    )
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Full -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Full -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' },
+        [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }
+    )
+    children = [array]@(
+        [string]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Full -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Full -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' },
+        [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }
+    )
+    children = [System.Object[]]@(
+        [System.String]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -ExpandDepth 1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandDepth 1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }
+    phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' })
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Full -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Full -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }
+    phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' })
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Full -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Full -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }
+    phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' })
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Full -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Full -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }
+    phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' })
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -ExpandDepth 0' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandDepth 0
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = [string]'John'; last_name = [string]'Smith'; is_alive = [bool]$True; age = [int]27; address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }; phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }); children = [array]@([string]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Full -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Full -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = [System.String]'John'; last_name = [System.String]'Smith'; is_alive = [System.Boolean]$True; age = [System.Int32]27; address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }; phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }); children = [System.Object[]]@([System.String]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Full -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Full -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = [string]'John'; last_name = [string]'Smith'; is_alive = [bool]$True; age = [int]27; address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }; phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }); children = [array]@([string]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Full -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Full -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = [System.String]'John'; last_name = [System.String]'Smith'; is_alive = [System.Boolean]$True; age = [System.Int32]27; address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }; phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }); children = [System.Object[]]@([System.String]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -ExpandDepth -1' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandDepth -1
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234';type=[string]'home' }, [hashtable]@{ number=[string]'646 555-4567';type=[string]'office' });children=[array]@([string]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234';type=[System.String]'home' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567';type=[System.String]'office' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234';type=[string]'home' }, [hashtable]@{ number=[string]'646 555-4567';type=[string]'office' });children=[array]@([string]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -FullTypeName' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -FullTypeName
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234';type=[System.String]'home' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567';type=[System.String]'office' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{
+            number = [string]'212 555-1234'
+            type = [string]'home'
+        },
+        [hashtable]@{
+            number = [string]'646 555-4567'
+            type = [string]'office'
+        }
+    )
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{
+            number = [System.String]'212 555-1234'
+            type = [System.String]'home'
+        },
+        [System.Collections.Hashtable]@{
+            number = [System.String]'646 555-4567'
+            type = [System.String]'office'
+        }
+    )
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{
+            number = [string]'212 555-1234'
+            type = [string]'home'
+        },
+        [hashtable]@{
+            number = [string]'646 555-4567'
+            type = [string]'office'
+        }
+    )
+    children = [array]@(
+        [string]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{
+            number = [System.String]'212 555-1234'
+            type = [System.String]'home'
+        },
+        [System.Collections.Hashtable]@{
+            number = [System.String]'646 555-4567'
+            type = [System.String]'office'
+        }
+    )
+    children = [System.Object[]]@(
+        [System.String]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' },
+        [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }
+    )
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 2 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 2 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' },
+        [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }
+    )
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 2 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 2 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{
+        street_address = [string]'21 2nd Street'
+        city = [string]'New York'
+        state = [string]'NY'
+        postal_code = [string]'10021-3100'
+    }
+    phone_numbers = [array]@(
+        [hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' },
+        [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }
+    )
+    children = [array]@(
+        [string]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 2 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 2 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{
+        street_address = [System.String]'21 2nd Street'
+        city = [System.String]'New York'
+        state = [System.String]'NY'
+        postal_code = [System.String]'10021-3100'
+    }
+    phone_numbers = [System.Object[]]@(
+        [System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' },
+        [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }
+    )
+    children = [System.Object[]]@(
+        [System.String]'Catherine'
+    )
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }
+    phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' })
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 1 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 1 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }
+    phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' })
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 1 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 1 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{
+    first_name = [string]'John'
+    last_name = [string]'Smith'
+    is_alive = [bool]$True
+    age = [int]27
+    address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }
+    phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' })
+    children = [array]@([string]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 1 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 1 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{
+    first_name = [System.String]'John'
+    last_name = [System.String]'Smith'
+    is_alive = [System.Boolean]$True
+    age = [System.Int32]27
+    address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }
+    phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' })
+    children = [System.Object[]]@([System.String]'Catherine')
+    spouse = $Null
+}
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = [string]'John'; last_name = [string]'Smith'; is_alive = [bool]$True; age = [int]27; address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }; phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }); children = [array]@([string]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 0 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 0 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = [System.String]'John'; last_name = [System.String]'Smith'; is_alive = [System.Boolean]$True; age = [System.Int32]27; address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }; phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }); children = [System.Object[]]@([System.String]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth 0 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth 0 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name = [string]'John'; last_name = [string]'Smith'; is_alive = [bool]$True; age = [int]27; address = [PSCustomObject]@{ street_address = [string]'21 2nd Street'; city = [string]'New York'; state = [string]'NY'; postal_code = [string]'10021-3100' }; phone_numbers = [array]@([hashtable]@{ number = [string]'212 555-1234'; type = [string]'home' }, [hashtable]@{ number = [string]'646 555-4567'; type = [string]'office' }); children = [array]@([string]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth 0 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth 0 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name = [System.String]'John'; last_name = [System.String]'Smith'; is_alive = [System.Boolean]$True; age = [System.Int32]27; address = [System.Management.Automation.PSObject]@{ street_address = [System.String]'21 2nd Street'; city = [System.String]'New York'; state = [System.String]'NY'; postal_code = [System.String]'10021-3100' }; phone_numbers = [System.Object[]]@([System.Collections.Hashtable]@{ number = [System.String]'212 555-1234'; type = [System.String]'home' }, [System.Collections.Hashtable]@{ number = [System.String]'646 555-4567'; type = [System.String]'office' }); children = [System.Object[]]@([System.String]'Catherine'); spouse = $Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234';type=[string]'home' }, [hashtable]@{ number=[string]'646 555-4567';type=[string]'office' });children=[array]@([string]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Full -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Full -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234';type=[System.String]'home' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567';type=[System.String]'office' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234';type=[string]'home' }, [hashtable]@{ number=[string]'646 555-4567';type=[string]'office' });children=[array]@([string]'Catherine');spouse=$Null }
+'@
+        }
+        It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit' {
+            $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit
+            { Invoke-Expression $Expression } | Should -not -Throw
+            $Expression | Should -Be @'
+[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234';type=[System.String]'home' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567';type=[System.String]'office' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+'@
+        }
+    }
+
     Context 'Issues' {
 
         It '#59 quoting bug' {
-            @{ Test = "foo'bar" } | ConvertTo-Expression | Should -Contain "    Test = 'foo''bar'"
+            @{ Test = "foo'bar" } | ConvertTo-Expression | Should -Be "@{ Test = 'foo''bar' }"
         }
     }
 }

--- a/Tests/PSExpression.IsContrainedType.Test.ps1
+++ b/Tests/PSExpression.IsContrainedType.Test.ps1
@@ -1,0 +1,500 @@
+#Requires -Modules @{ModuleName="Pester"; ModuleVersion="5.5.0"}
+
+using module ..\..\ObjectGraphTools
+
+param()
+
+Describe 'PSExpression' {
+
+    BeforeAll {
+
+        Set-StrictMode -Version Latest
+
+    }
+
+    Context 'Is constrained type' {
+
+        It 'Adsi' {
+            $Type = 'Adsi' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'AdsiSearcher' {
+            $Type = 'AdsiSearcher' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Alias' {
+            $Type = 'Alias' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'AllowEmptyCollection' {
+            $Type = 'AllowEmptyCollection' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'AllowEmptyString' {
+            $Type = 'AllowEmptyString' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'AllowNull' {
+            $Type = 'AllowNull' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ArgumentCompleter' {
+            $Type = 'ArgumentCompleter' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ArgumentCompletions' {
+            $Type = 'ArgumentCompletions' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [ArgumentCompletions] doesn't exists in Windows PowerShell
+        }
+
+        It 'Array' {
+            $Type = 'Array' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'BigInt' {
+            $Type = 'BigInt' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Bool' {
+            $Type = 'Bool' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Byte' {
+            $Type = 'Byte' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Char' {
+            $Type = 'Char' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'CimClass' {
+            $Type = 'CimClass' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'CimConverter' {
+            $Type = 'CimConverter' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'CimInstance' {
+            $Type = 'CimInstance' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'CimSession' {
+            $Type = 'CimSession' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'CimType' {
+            $Type = 'CimType' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'CmdletBinding' {
+            $Type = 'CmdletBinding' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'CultureInfo' {
+            $Type = 'CultureInfo' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'DateTime' {
+            $Type = 'DateTime' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Decimal' {
+            $Type = 'Decimal' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Double' {
+            $Type = 'Double' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'DscLocalConfigurationManager' {
+            $Type = 'DscLocalConfigurationManager' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'DscProperty' {
+            $Type = 'DscProperty' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'DscResource' {
+            $Type = 'DscResource' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ExperimentAction' {
+            $Type = 'ExperimentAction' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [ExperimentAction] doesn't exists in Windows PowerShell
+        }
+
+        It 'Experimental' {
+            $Type = 'Experimental' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [Experimental] doesn't exists in Windows PowerShell
+        }
+
+        It 'ExperimentalFeature' {
+            $Type = 'ExperimentalFeature' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [ExperimentalFeature] doesn't exists in Windows PowerShell
+        }
+
+        It 'Float' {
+            $Type = 'Float' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Guid' {
+            $Type = 'Guid' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Hashtable' {
+            $Type = 'Hashtable' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Int' {
+            $Type = 'Int' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Int16' {
+            $Type = 'Int16' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Int32' {
+            $Type = 'Int32' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Int64' {
+            $Type = 'Int64' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'IpAddress' {
+            $Type = 'IpAddress' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'IPEndpoint' {
+            $Type = 'IPEndpoint' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Long' {
+            $Type = 'Long' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'MailAddress' {
+            $Type = 'MailAddress' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Microsoft.PowerShell.Commands.ModuleSpecification' {
+            $Type = 'Microsoft.PowerShell.Commands.ModuleSpecification' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'NoRunSpaceAffinity' {
+            $Type = 'NoRunSpaceAffinity' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [NoRunSpaceAffinity] doesn't exists in Windows PowerShell
+        }
+
+        It 'NullString' {
+            $Type = 'NullString' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Object' {
+            $Type = 'Object' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ObjectSecurity' {
+            $Type = 'ObjectSecurity' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Ordered' {
+            $Type = 'Ordered' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [Ordered] doesn't exists in Windows PowerShell
+        }
+
+        It 'OutputType' {
+            $Type = 'OutputType' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Parameter' {
+            $Type = 'Parameter' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PhysicalAddress' {
+            $Type = 'PhysicalAddress' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PSCredential' {
+            $Type = 'PSCredential' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PSCustomObject' {
+            $Type = 'PSCustomObject' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PSDefaultValue' {
+            $Type = 'PSDefaultValue' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PSListModifier' {
+            $Type = 'PSListModifier' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PSObject' {
+            $Type = 'PSObject' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PSPrimitiveDictionary' {
+            $Type = 'PSPrimitiveDictionary' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'PSTypeNameAttribute' {
+            $Type = 'PSTypeNameAttribute' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Ref' {
+            $Type = 'Ref' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Regex' {
+            $Type = 'Regex' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'SByte' {
+            $Type = 'SByte' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'SecureString' {
+            $Type = 'SecureString' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'SemVer' {
+            $Type = 'SemVer' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [SemVer] doesn't exists in Windows PowerShell
+        }
+
+        It 'Short' {
+            $Type = 'Short' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [Short] doesn't exists in Windows PowerShell
+        }
+
+        It 'Single' {
+            $Type = 'Single' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'String' {
+            $Type = 'String' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'SupportsWildcards' {
+            $Type = 'SupportsWildcards' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Switch' {
+            $Type = 'Switch' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'TimeSpan' {
+            $Type = 'TimeSpan' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'UInt' {
+            $Type = 'UInt' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [UInt] doesn't exists in Windows PowerShell
+        }
+
+        It 'UInt16' {
+            $Type = 'UInt16' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'UInt32' {
+            $Type = 'UInt32' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'UInt64' {
+            $Type = 'UInt64' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ULong' {
+            $Type = 'ULong' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [ULong] doesn't exists in Windows PowerShell
+        }
+
+        It 'Uri' {
+            $Type = 'Uri' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'UShort' {
+            $Type = 'UShort' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [UShort] doesn't exists in Windows PowerShell
+        }
+
+        It 'ValidateCount' {
+            $Type = 'ValidateCount' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateDrive' {
+            $Type = 'ValidateDrive' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateLength' {
+            $Type = 'ValidateLength' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateNotNull' {
+            $Type = 'ValidateNotNull' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateNotNullOrEmpty' {
+            $Type = 'ValidateNotNullOrEmpty' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateNotNullOrWhiteSpace' {
+            $Type = 'ValidateNotNullOrWhiteSpace' -as [Type]
+            if ($Type) { [PSExpression]::IsConstrainedType($Type) | Should -BeTrue } # else [ValidateNotNullOrWhiteSpace] doesn't exists in Windows PowerShell
+        }
+
+        It 'ValidatePattern' {
+            $Type = 'ValidatePattern' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateRange' {
+            $Type = 'ValidateRange' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateScript' {
+            $Type = 'ValidateScript' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateSet' {
+            $Type = 'ValidateSet' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateTrustedData' {
+            $Type = 'ValidateTrustedData' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'ValidateUserDrive' {
+            $Type = 'ValidateUserDrive' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Version' {
+            $Type = 'Version' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Void' {
+            $Type = 'Void' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'WildcardPattern' {
+            $Type = 'WildcardPattern' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Wmi' {
+            $Type = 'Wmi' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'WmiClass' {
+            $Type = 'WmiClass' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'WmiSearcher' {
+            $Type = 'WmiSearcher' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'X500DistinguishedName' {
+            $Type = 'X500DistinguishedName' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'X509Certificate' {
+            $Type = 'X509Certificate' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+
+        It 'Xml' {
+            $Type = 'Xml' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeTrue
+        }
+    }
+
+Context 'Is NOT constrained type' {
+
+        It 'System.Management.Automation.Language.AST' {
+            $Type = 'System.Management.Automation.Language.AST' -as [Type]
+            [PSExpression]::IsConstrainedType($Type) | Should -BeFalse
+        }
+    }
+}

--- a/WhatsNew.md
+++ b/WhatsNew.md
@@ -1,3 +1,15 @@
+## 2024-04-04 0.1.2 (iRon)
+  - Enhancements
+    - Full implementation of `ConvertTo-Expression`
+      (still requires some code improvements with regards to hardcoded roundtrip properties)
+      Improved performance and added parameters:
+      `-LanguageMode` Restricted, Constrained, Full
+      `-ExpandDepth` Expands up till this level (collapse the rest)
+      `-Explicit` Add explicit type name
+      `-FullTypeName` Use full type name
+      `-HighFidelity` Explore all underlying properties
+      `-ExpandSingleton` Expand collection nodes with a single item
+
 ## 2024-03-09 0.1.1 (iRon)
   - Fixes
     - #45 Improved internal nodes collector
@@ -11,7 +23,7 @@
     - #55 `Get-Node` retrieves no long the path but the Object/Node from the pipeline
     - #56 Removed -Path parameter from Get-ChildNode (Use: `<Object-Graph or PSNode> | Get-Node <XdnPath> | Get-ChildNode ...` )
 
-  -Enhancements
+  - Enhancements
     - Full **Extended dot notation** (`Xdn`) implementation (see: https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/Xdn.md)
     - #57 Added `-Literal` parameter to `Get-Node`
     - Added `Xdn` document


### PR DESCRIPTION
## 2024-04-04 0.1.2 (iRon)
  - Enhancements
    - Full implementation of `ConvertTo-Expression`
      (still requires some code improvements with regards to hardcoded roundtrip properties)
      Improved performance and added parameters:
      `-LanguageMode` Restricted, Constrained, Full
      `-ExpandDepth` Expands up till this level (collapse the rest)
      `-Explicit` Add explicit type name
      `-FullTypeName` Use full type name
      `-HighFidelity` Explore all underlying properties
      `-ExpandSingleton` Expand collection nodes with a single item