### PR TITLE
Implemented #87, #89, #90, #91 and #92

### DIFF
--- a/Docs/Compare-ObjectGraph.md
+++ b/Docs/Compare-ObjectGraph.md
@@ -13,7 +13,8 @@ Compare-ObjectGraph
     [-IsEqual]
     [-MatchCase]
     [-MatchType]
-    [-MatchOrder]
+    [-IgnoreListOrder]
+    [-MatchMapOrder]
     [-MaxDepth <Int32> = [PSNode]::DefaultMaxDepth]
     [<CommonParameters>]
 ```
@@ -22,7 +23,7 @@ Compare-ObjectGraph
 
 Deep compares two Object Graph and lists the differences between them.
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 
@@ -124,19 +125,26 @@ Unless the `-MatchType` switch is provided, a loosely (inclusive) comparison is 
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
 
-### <a id="-matchorder">**`-MatchOrder`**</a>
+### <a id="-ignorelistorder">**`-IgnoreListOrder`**</a>
 
-By default, items in a list and dictionary (including properties of an PSCustomObject or Component Object)
-are matched independent of the order. If the `-MatchOrder` switch is supplied the index of the concerned
-item (or property) is matched.
+<table>
+<tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Management.Automation.SwitchParameter">SwitchParameter</a></td></tr>
+<tr><td>Mandatory:</td><td>False</td></tr>
+<tr><td>Position:</td><td>Named</td></tr>
+<tr><td>Default value:</td><td></td></tr>
+<tr><td>Accept pipeline input:</td><td>False</td></tr>
+<tr><td>Accept wildcard characters:</td><td>False</td></tr>
+</table>
+
+### <a id="-matchmaporder">**`-MatchMapOrder`**</a>
+
+By default, items in dictionary (including properties of an PSCustomObject or Component Object) are
+matched by their key name (independent of the order).
+If the `-MatchMapOrder` switch is supplied, each entry is also validated by the position.
 
 > [!NOTE]
-> A `[HashTable]` type is unordered by design and therefore, regardless the `-MatchOrder` switch, the order
-> of the `[HashTable]` are always ignored.
-
-> [!NOTE]
-> Regardless of the `-MatchOrder` switch, indexed (defined by the [PrimaryKey](#primarykey) parameter) dictionaries
-(including PSCustomObject or Component Objects) in a list are matched independent of the order.
+> A `[HashTable]` type is unordered by design and therefore, regardless the `-MatchMapOrder` switch,
+the order of the `[HashTable]` (defined by the `$Reference`) are always ignored.
 
 <table>
 <tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Management.Automation.SwitchParameter">SwitchParameter</a></td></tr>

--- a/Docs/ConvertFrom-Expression.md
+++ b/Docs/ConvertFrom-Expression.md
@@ -8,9 +8,9 @@ Deserializes a PowerShell expression to an object.
 ```PowerShell
 ConvertFrom-Expression
     -InputObject <String>
-    [-ArrayAs <Object>]
-    [-HashTableAs <Object>]
     [-LanguageMode <PSLanguageMode> = 'Restricted']
+    [-ListAs <Object>]
+    [-MapAs <Object>]
     [<CommonParameters>]
 ```
 
@@ -19,7 +19,7 @@ ConvertFrom-Expression
 The `ConvertFrom-Expression` cmdlet safely converts a PowerShell formatted expression to an object-graph
 existing of a mixture of nested arrays, hashtables and objects that contain a list of strings and values.
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <String>`**</a>
 
@@ -32,34 +32,6 @@ The **InputObject** value can't be `$null` or an empty string.
 <table>
 <tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.String">String</a></td></tr>
 <tr><td>Mandatory:</td><td>True</td></tr>
-<tr><td>Position:</td><td>Named</td></tr>
-<tr><td>Default value:</td><td></td></tr>
-<tr><td>Accept pipeline input:</td><td>False</td></tr>
-<tr><td>Accept wildcard characters:</td><td>False</td></tr>
-</table>
-
-### <a id="-arrayas">**`-ArrayAs <Object>`**</a>
-
-If supplied, the array subexpression `@( )` syntaxes without an type initializer or with an unknown or
-denied type initializer will be converted to the given list type.
-
-<table>
-<tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Object">Object</a></td></tr>
-<tr><td>Mandatory:</td><td>False</td></tr>
-<tr><td>Position:</td><td>Named</td></tr>
-<tr><td>Default value:</td><td></td></tr>
-<tr><td>Accept pipeline input:</td><td>False</td></tr>
-<tr><td>Accept wildcard characters:</td><td>False</td></tr>
-</table>
-
-### <a id="-hashtableas">**`-HashTableAs <Object>`**</a>
-
-If supplied, the array subexpression `@{ }` syntaxes without an type initializer or with an unknown or
-denied type initializer will be converted to the given map (dictionary or object) type.
-
-<table>
-<tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Object">Object</a></td></tr>
-<tr><td>Mandatory:</td><td>False</td></tr>
 <tr><td>Position:</td><td>Named</td></tr>
 <tr><td>Default value:</td><td></td></tr>
 <tr><td>Accept pipeline input:</td><td>False</td></tr>
@@ -89,6 +61,34 @@ Defines which object types are allowed for the deserialization, see: [About lang
 <tr><td>Mandatory:</td><td>False</td></tr>
 <tr><td>Position:</td><td>Named</td></tr>
 <tr><td>Default value:</td><td><code>'Restricted'</code></td></tr>
+<tr><td>Accept pipeline input:</td><td>False</td></tr>
+<tr><td>Accept wildcard characters:</td><td>False</td></tr>
+</table>
+
+### <a id="-listas">**`-ListAs <Object>`**</a>
+
+If supplied, the array subexpression `@( )` syntaxes without an type initializer or with an unknown
+or denied type initializer will be converted to the given list type.
+
+<table>
+<tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Object">Object</a></td></tr>
+<tr><td>Mandatory:</td><td>False</td></tr>
+<tr><td>Position:</td><td>Named</td></tr>
+<tr><td>Default value:</td><td></td></tr>
+<tr><td>Accept pipeline input:</td><td>False</td></tr>
+<tr><td>Accept wildcard characters:</td><td>False</td></tr>
+</table>
+
+### <a id="-mapas">**`-MapAs <Object>`**</a>
+
+If supplied, the Hash table literal syntax `@{ }` syntaxes without an type initializer or with an unknown
+or denied type initializer will be converted to the given map (dictionary or object) type.
+
+<table>
+<tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Object">Object</a></td></tr>
+<tr><td>Mandatory:</td><td>False</td></tr>
+<tr><td>Position:</td><td>Named</td></tr>
+<tr><td>Default value:</td><td></td></tr>
 <tr><td>Accept pipeline input:</td><td>False</td></tr>
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>

--- a/Docs/ConvertTo-Expression.md
+++ b/Docs/ConvertTo-Expression.md
@@ -25,18 +25,21 @@ The ConvertTo-Expression cmdlet converts (serializes) an object to a PowerShell 
 The object can be stored in a variable, (.psd1) file or any other common storage for later use or to be ported
 to another system.
 
-expressions might be restored to an object using the native Invoke-Expression cmdlet:
+expressions might be restored to an object using the native [`Invoke-Expression`](https://go.microsoft.com/fwlink/?LinkID=2097030) cmdlet:
 
 ```PowerShell
 $Object = Invoke-Expression ($Object | ConvertTo-Expression)
 ```
 
-Or using the [PSNode Object Parser][1] (*under construction*).
+> [!Warning]
+> Take reasonable precautions when using the Invoke-Expression cmdlet in scripts. When using `Invoke-Expression`
+> to run a command that the user enters, verify that the command is safe to run before running it.
+> In general, it is best to restore your objects using [`ConvertFrom-Expression`](https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/ConvertFrom-Expression.md).
 
 > [!Note]
-> Some object types can not be constructed from a a simple serialized expression
+> Some object types can not be reconstructed from a simple serialized expression.
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 

--- a/Docs/Copy-ObjectGraph.md
+++ b/Docs/Copy-ObjectGraph.md
@@ -42,7 +42,7 @@ $PSObject = Copy-ObjectGraph $Object -ListAs [Array] -DictionaryAs PSCustomObjec
 $PSObject = $Json | ConvertFrom-Json | Copy-ObjectGraph -DictionaryAs ([Ordered]@{})
 ```
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 

--- a/Docs/Export-ObjectGraph.md
+++ b/Docs/Export-ObjectGraph.md
@@ -37,7 +37,7 @@ Export-ObjectGraph
 The `Export-ObjectGraph` cmdlet converts a PowerShell (complex) object to an PowerShell expression
 and exports it to a PowerShell (`.ps1`) file or a PowerShell data (`.psd1`) file.
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 

--- a/Docs/Get-ChildNode.md
+++ b/Docs/Get-ChildNode.md
@@ -120,7 +120,7 @@ ConvertTo-Expression $Object
 
 See the [PowerShell Object Parser][1] For details on the `[PSNode]` properties and methods.
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 

--- a/Docs/Get-Node.md
+++ b/Docs/Get-Node.md
@@ -8,7 +8,7 @@ Get a node
 ```PowerShell
 Get-Node
     -InputObject <Object>
-    [-Literal]
+    [-Unique]
     [-MaxDepth <Int32>]
     [<CommonParameters>]
 ```
@@ -16,6 +16,7 @@ Get-Node
 ```PowerShell
 Get-Node
     [-Path <Object>]
+    [-Literal]
     [<CommonParameters>]
 ```
 
@@ -96,7 +97,7 @@ $ObjectGraph | ConvertTo-Expression
 
 for more details, see: [PowerShell Object Parser][1] and [Extended dot notation][2]
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 
@@ -116,9 +117,9 @@ The concerned object graph or node.
 Specifies the path to a specific node in the object graph.
 The path might be either:
 
-* As [String](#string) a "dot-property" selection as defined by the `PathName` property a specific node.
-* A array of strings (dictionary keys or Property names) and/or Integers (list indices).
-* A object (`PSNode[]`) list where each `Name` property defines the path
+* A dot-notation (`[String]`) literal or expression (as natively used with PowerShell)
+* A array of strings (dictionary keys or Property names) and/or integers (list indices)
+* A `[PSNodePath]` (such as `$Node.Path`) or a `[XdnPath]` (Extended Dot-Notation) object
 
 <table>
 <tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Object">Object</a></td></tr>
@@ -132,6 +133,20 @@ The path might be either:
 ### <a id="-literal">**`-Literal`**</a>
 
 If Literal switch is set, all (map) nodes in the given path are considered literal.
+
+<table>
+<tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Management.Automation.SwitchParameter">SwitchParameter</a></td></tr>
+<tr><td>Mandatory:</td><td>False</td></tr>
+<tr><td>Position:</td><td>Named</td></tr>
+<tr><td>Default value:</td><td></td></tr>
+<tr><td>Accept pipeline input:</td><td>False</td></tr>
+<tr><td>Accept wildcard characters:</td><td>False</td></tr>
+</table>
+
+### <a id="-unique">**`-Unique`**</a>
+
+Specifies that if a subset of the nodes has identical properties and values,
+only a single node of the subset should be selected.
 
 <table>
 <tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Management.Automation.SwitchParameter">SwitchParameter</a></td></tr>

--- a/Docs/Import-ObjectGraph.md
+++ b/Docs/Import-ObjectGraph.md
@@ -19,8 +19,8 @@ Import-ObjectGraph
 
 ```PowerShell
 Import-ObjectGraph
-    [-ArrayAs <Object>]
-    [-HashTableAs <Object>]
+    [-ListAs <Object>]
+    [-MapAs <Object>]
     [-LanguageMode <PSLanguageMode>]
     [-Encoding <Object>]
     [<CommonParameters>]
@@ -32,7 +32,7 @@ The `Import-ObjectGraph` cmdlet safely converts a PowerShell formatted expressio
 to an object-graph existing of a mixture of nested arrays, hashtables and objects that contain a list
 of strings and values.
 
-## Parameter
+## Parameters
 
 ### <a id="-path">**`-Path <String[]>`**</a>
 
@@ -64,7 +64,7 @@ PowerShell not to interpret any characters as escape sequences.
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
 
-### <a id="-arrayas">**`-ArrayAs <Object>`**</a>
+### <a id="-listas">**`-ListAs <Object>`**</a>
 
 If supplied, the array subexpression `@( )` syntaxes without an type initializer or with an unknown or
 denied type initializer will be converted to the given list type.
@@ -78,12 +78,12 @@ denied type initializer will be converted to the given list type.
 <tr><td>Accept wildcard characters:</td><td>False</td></tr>
 </table>
 
-### <a id="-hashtableas">**`-HashTableAs <Object>`**</a>
+### <a id="-mapas">**`-MapAs <Object>`**</a>
 
 If supplied, the array subexpression `@{ }` syntaxes without an type initializer or with an unknown or
 denied type initializer will be converted to the given map (dictionary or object) type.
 
-The default `HashTableAs` is an (ordered) `PSCustomObject` for PowerShell Data (`psd1`) files and
+The default `MapAs` is an (ordered) `PSCustomObject` for PowerShell Data (`psd1`) files and
 a (unordered) `HashTable` for any other files, which usually concerns PowerShell (`.ps1`) files that
 support explicit type initiators.
 

--- a/Docs/Merge-ObjectGraph.md
+++ b/Docs/Merge-ObjectGraph.md
@@ -19,7 +19,7 @@ Merge-ObjectGraph
 
 Recursively merges two object graphs into a new object graph.
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 

--- a/Docs/SchemaObject.md
+++ b/Docs/SchemaObject.md
@@ -1,0 +1,32 @@
+Each schema definition requires at least one `map` node and a possible additional collection node to hold the child items.
+This means:
+
+* The validation of a **Leaf** node requires a single schema `map` node, e.g.:
+
+```PowerShell
+@{ Type = 'String' }
+```
+
+* The validation of a **list** node requires a single schema `map` node that contains an embedded `list` node named "**items**", e.g.:
+
+```PowerShell
+@{
+    Type = 'Array'
+    Items = @(
+        ...
+    )
+}
+```
+
+* The validation of a **map** node requires a single schema `map` node that contains another embedded `map` node named "**items**", e.g.:
+
+```PowerShell
+@{
+    Type = 'Array'
+    Items = @{
+        ...
+    }
+}
+```
+
+The object-graph schema depth required to describe every node in an given object requires `2 * (maximum object depth) - 1`.

--- a/Docs/Sort-ObjectGraph.md
+++ b/Docs/Sort-ObjectGraph.md
@@ -19,7 +19,7 @@ ConvertTo-SortedObjectGraph
 
 Recursively sorts a object graph.
 
-## Parameter
+## Parameters
 
 ### <a id="-inputobject">**`-InputObject <Object>`**</a>
 
@@ -61,7 +61,7 @@ It is allowed to supply multiple primary keys.
 
 ### <a id="-matchcase">**`-MatchCase`**</a>
 
-Indicates that the sort is case-sensitive. By default, sorts aren't case-sensitive.
+(Alias `-CaseSensitive`) Indicates that the sort is case-sensitive. By default, sorts aren't case-sensitive.
 
 <table>
 <tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Management.Automation.SwitchParameter">SwitchParameter</a></td></tr>

--- a/Docs/Xdn.md
+++ b/Docs/Xdn.md
@@ -85,8 +85,8 @@ Select all the node from the `Book` nodes:
 ```
 $ObjectGraph | Get-Node BookStore.Book.*
 
-PathName                Name  Depth               Value
---------                ----  -----               -----
+Path                    Name  Depth               Value
+----                    ----  -----               -----
 BookStore[0].Book.Price Price     4               29.99
 BookStore[0].Book.Title Title     4        Harry Potter
 BookStore[1].Book.Price Price     4               39.95
@@ -105,8 +105,8 @@ Select the title from the first book:
 $1stTitle  = $ObjectGraph | Get-Node BookStore[0].Book.Title
 $1StTitle
 
-PathName                Name  Depth Value
---------                ----  ----- -----
+Path                    Name  Depth Value
+----                    ----  ----- -----
 BookStore[0].Book.Title Title     4 Harry Potter
 ```
 
@@ -115,8 +115,8 @@ Select the parent node of the `$1StTitle` node:
 ```PowerShell
 $1stTitle | Get-Node ..
 
-PathName          Name Depth Value
---------          ---- ----- -----
+Path              Name Depth Value
+----              ---- ----- -----
 BookStore[0].Book Book     3 {Price, Title}
 ```
 
@@ -134,8 +134,8 @@ Select all the descendant `title` nodes from the `BookStore` node:
 ```PowerShell
 $ObjectGraph | Get-Node BookStore~Title
 
-PathName                Name  Depth Value
---------                ----  ----- -----
+Path                    Name  Depth Value
+----                    ----  ----- -----
 BookStore[0].Book.Title Title     4 Harry Potter
 BookStore[1].Book.Title Title     4 Learning PowerShell
 ```
@@ -205,8 +205,8 @@ Select all the PowerShell and Python books:
 ```PowerShell
 $ObjectGraph | Get-Node BookStore~Title=*PowerShell*/*Python*
 
-PathName                Name  Depth Value
---------                ----  ----- -----
+Path                    Name  Depth Value
+----                    ----  ----- -----
 BookStore[1].Book.Title Title     4 Learning PowerShell
 ```
 

--- a/ObjectGraphTools.psd1
+++ b/ObjectGraphTools.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ObjectGraphTools.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.1.5'
+    ModuleVersion = '0.2.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -70,6 +70,7 @@
         'Get-ChildNode',
         'Get-Node',
         'Merge-ObjectGraph',
+        'Test-ObjectGraph',
         'ConvertTo-SortedObjectGraph'
     )
 

--- a/Source/Classes/ObjectParser.ps1
+++ b/Source/Classes/ObjectParser.ps1
@@ -193,7 +193,7 @@ if (@(`$Invoke).Count -gt 1) { `$Output } else { ,`$Output }
                     $TypeData.Force      = $Force
                     Update-TypeData @TypeData
                 }
-                else { Write-Warning "A 'set_$MemberName()' accessor requires a 'get_$MemberName()' accessor." }
+                else { Write-Warning "'[$ClassName].set_$MemberName()' accessor requires a '[$ClassName].get_$MemberName()' accessor." }
             }
         }
     }
@@ -266,34 +266,124 @@ function Set-View {
     }
 }
 
-Class LanguageType {
+Class PSLanguageType {
     hidden static $_TypeCache = [Dictionary[String,Bool]]::new()
-    hidden Static LanguageType() {
-        [LanguageType]::_TypeCache['System.Management.Automation.PSCustomObject'] = $True # https://github.com/PowerShell/PowerShell/issues/20767
+    hidden Static PSLanguageType() {
+        [PSLanguageType]::_TypeCache['System.Management.Automation.PSCustomObject'] = $True # https://github.com/PowerShell/PowerShell/issues/20767
     }
-    static [Bool]IsConstrained([Type]$Type) { # https://stackoverflow.com/a/64806919/1701026
-        if ($Null -eq $Type) { Throw 'The type can not be $Null' }
-        $FullName = $Type.FullName
-        if (-not [LanguageType]::_TypeCache.ContainsKey($FullName)) {
-            [LanguageType]::_TypeCache[$FullName] = try {
+    [Bool]IsRestricted($TypeName) {
+        if ($Null -eq $TypeName) { return $True } # Warning: a $Null is considered a restricted "type"!
+        $Type = $TypeName -as [Type]
+        if ($Null -eq $Type) { Throw 'Unknown type name: $TypeName' }
+        $TypeName = $Type.FullName
+        return $TypeName -in 'bool', 'array', 'hashtable'
+    }
+    [Bool]IsConstrained($TypeName) { # https://stackoverflow.com/a/64806919/1701026
+        if ($Null -eq $TypeName) { return $True } # Warning: a $Null is considered a constrained "type"!
+        $Type = $TypeName -as [Type]
+        if ($Null -eq $Type) { Throw 'Unknown type name: $TypeName' }
+        $TypeName = $Type.FullName
+        if (-not [PSLanguageType]::_TypeCache.ContainsKey($TypeName)) {
+            [PSLanguageType]::_TypeCache[$TypeName] = try {
                 $ConstrainedSession = [PowerShell]::Create()
                 $ConstrainedSession.RunSpace.SessionStateProxy.LanguageMode = 'Constrained'
-                $ConstrainedSession.AddScript("[$FullName]0").Invoke().Count -ne 0 -or
+                $ConstrainedSession.AddScript("[$TypeName]0").Invoke().Count -ne 0 -or
                 $ConstrainedSession.Streams.Error[0].FullyQualifiedErrorId -ne 'ConversionSupportedOnlyToCoreTypes'
             } catch { $False }
         }
-        return [LanguageType]::_TypeCache[$FullName]
+        return [PSLanguageType]::_TypeCache[$TypeName]
     }
 }
 
-# ____  ____ ____            _       _ _
+New-Variable -Scope Global -Name PSLanguageType -Value ([PSLanguageType]::new()) -Force
+
+Class PSInstance {
+    static [Object]Create($Object) {
+        if ($Null -eq $Object) { return $Null }
+        elseif ($Object -is [String]) {
+            $String = if ($Object.StartsWith('[') -and $Object.EndsWith(']')) { $Object.SubString(1, ($Object.Length - 2)) } else { $Object }
+            Switch -Regex ($String) {
+                '^((System\.)?String)?$'                                         { return '' }
+                '^(System\.)?Array$'                                             { return ,@() }
+                '^(System\.)?Object\[\]$'                                        { return ,@() }
+                '^((System\.)?Collections\.Hashtable\.)?hashtable$'              { return @{} }
+                '^((System\.)?Management\.Automation\.)?ScriptBlock$'            { return {} }
+                '^((System\.)?Collections\.Specialized\.)?Ordered(Dictionary)?$' { return [Ordered]@{} }
+                '^((System\.)?Management\.Automation\.)?PS(Custom)?Object$'      { return [PSCustomObject]@{} }
+            }
+            $Type = $String -as [Type]
+            if (-not $Type) { Throw "Unknown type: [$Object]" }
+        }
+        elseif ($Object -is [Type]) {
+            $Type = $Object.UnderlyingSystemType
+            if     ("$Type" -eq 'string')      { Return '' }
+            elseif ("$Type" -eq 'array')       { Return ,@() }
+            elseif ("$Type" -eq 'scriptblock') { Return {} }
+        }
+        else {
+            if     ($Object -is [Object[]])       { Return ,@() }
+            elseif ($Object -is [ScriptBlock])    { Return {} }
+            elseif ($Object -is [PSCustomObject]) { Return [PSCustomObject]::new() }
+            $Type = $Object.GetType()
+        }
+        try { return [Activator]::CreateInstance($Type) } catch { throw $_ }
+    }
+
+}
+
+#  ____  ____ ____            _       _ _
 # |  _ \/ ___/ ___|  ___ _ __(_) __ _| (_)_______
 # | |_) \___ \___ \ / _ \ '__| |/ _` | | |_  / _ \
 # |  __/ ___) |__) |  __/ |  | | (_| | | |/ /  __/
 # |_|   |____/____/ \___|_|  |_|\__,_|_|_/___\___|
 
+Class PSKeyExpression {
+    hidden static [Regex]$UnquoteMatch = '^[\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}_][\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}\p{Nd}_]*$' # https://stackoverflow.com/questions/62754771/unquoted-key-rules-and-best-practices
+    hidden $Key
+    hidden [PSLanguageMode]$LanguageMode = 'Restricted'
+    hidden [Bool]$Compress
+    hidden [Int]$MaximumLength
+
+    PSKeyExpression($Key)                                                 { $this.Key = $Key }
+    PSKeyExpression($Key, [PSLanguageMode]$LanguageMode)                  { $this.Key = $Key; $this.LanguageMode = $LanguageMode }
+    PSKeyExpression($Key, [PSLanguageMode]$LanguageMode, [Bool]$Compress) { $this.Key = $Key; $this.LanguageMode = $LanguageMode; $this.Compress = $Compress }
+    PSKeyExpression($Key, [int]$MaximumLength)                            { $this.Key = $Key; $this.MaximumLength = $MaximumLength }
+
+    [String]ToString() {
+        $Name = $this.Key
+        if ($Name -is [byte]  -or $Name -is [int16]  -or $Name -is [int32]  -or $Name -is [int64]  -or
+            $Name -is [sbyte] -or $Name -is [uint16] -or $Name -is [uint32] -or $Name -is [uint64] -or
+            $Name -is [float] -or $Name -is [double] -or $Name -is [decimal]) {
+            if ($this.MaximumLength -and $Name.Length -gt $this.MaximumLength) {
+                return "$Name".SubString(0, ($this.MaximumLength - 3)) + '...'
+            }
+            return $Name
+        }
+        if ($this.MaximumLength) { $Name = "$Name" }
+        if ($Name -is [String]) {
+            if ($Name -cMatch [PSKeyExpression]::UnquoteMatch) {
+                if ($this.MaximumLength -and $Name.Length -gt $this.MaximumLength) {
+                    return $Name.SubString(0, ($this.MaximumLength - 3)) + '...'
+                }
+                return $Name
+            }
+            $Name = $Name.Replace("'", "''")
+            if ($this.MaximumLength -and $this.MaximumLength -and $Name.Length -gt $this.MaximumLength - 2) {
+                $Name = $Name.SubString(0, ($this.MaximumLength - 5)) + '...'
+            }
+            return "'$Name'"
+        }
+        else {
+            $Node = [PSNode]::ParseInput($Name, 2) # There is no way (yet) to expand keys more than 2 levels
+            return  [PSSerialize]::new($Node, $this.LanguageMode, -$this.Compress)
+        }
+
+    }
+}
+
 Class PSSerialize {
     hidden static [String[]]$Parameters = 'LanguageMode', 'Explicit', 'FullTypeName', 'HighFidelity', 'Indent', 'ExpandSingleton'
+
     hidden [PSLanguageMode]$LanguageMode = 'Restricted'
     hidden [Int]$ExpandDepth = [Int]::MaxValue
     hidden [Bool]$Explicit
@@ -358,6 +448,11 @@ Class PSSerialize {
     hidden [Int]$LineNumber = 1
 
     PSSerialize($Object) { $this.Serialize($Object) }
+    PSSerialize($Object, $LanguageMode, $ExpandDepth) {
+        $this.LanguageMode = $LanguageMode
+        $this.ExpandDepth = $ExpandDepth
+        $this.Serialize($Object)
+    }
     PSSerialize(
         $Object,
         $LanguageMode    = 'Restricted',
@@ -391,8 +486,7 @@ Class PSSerialize {
             if ($this.FullTypeName) { Write-Warning 'The FullTypeName switch requires Constrained - or FullLanguage mode.' }
             if ($this.Explicit)     { Write-Warning 'The Explicit switch requires Constrained - or FullLanguage mode.' }
         }
-        if ($Object -is [PSNode]) { $Node = $Object }
-        else { $Node = [PSNode]::ParseInput($Object) }
+        if ($Object -is [PSNode]) { $Node = $Object } else { $Node = [PSNode]::ParseInput($Object) }
         $this.Iterate($Node)
         return $this.StringBuilder.ToString()
     }
@@ -409,7 +503,7 @@ Class PSSerialize {
             if ($Null -ne $Type -and (
                 $this.LanguageMode -eq 'Full' -or (
                         $this.LanguageMode -eq 'Constrained' -and
-                        [LanguageType]::IsConstrained($Type) -and (
+                        $Global:PSLanguageType.IsConstrained($Type) -and (
                             $this.Explicit -or -not (
                                 $Type.IsPrimitive      -or
                                 $Value -is [String]    -or
@@ -434,11 +528,11 @@ Class PSSerialize {
             $Expression =
                 if ([PSSerialize]::RoundTripProperty.Contains($Node.ValueType.FullName)) {
                     $Property = [PSSerialize]::RoundTripProperty[$Node.ValueType.FullName]
-                        if ($Null -eq $Property)                      { $Null }
-                    elseif ($Property -is [String])                   { if ($Property) { ,$Value.$Property } else { "$Value" } }
-                    elseif ($Property -is [ScriptBlock] )             { Invoke-Command $Property -InputObject $Value }
-                    elseif ($Property -is [HashTable])                { if ($this.LanguageMode -eq 'Restricted') { $Null } else { @{} } }
-                    elseif ($Property -is [Array])                    { @($Property.foreach{ $Value.$_ }) }
+                        if ($Null -eq $Property)          { $Null }
+                    elseif ($Property -is [String])       { if ($Property) { ,$Value.$Property } else { "$Value" } }
+                    elseif ($Property -is [ScriptBlock] ) { Invoke-Command $Property -InputObject $Value }
+                    elseif ($Property -is [HashTable])    { if ($this.LanguageMode -eq 'Restricted') { $Null } else { @{} } }
+                    elseif ($Property -is [Array])        { @($Property.foreach{ $Value.$_ }) }
                     else { Throw "Unknown round trip property type: $($Property.GetType())."}
                 }
                 elseif ($Type.IsPrimitive)                        { $Value }
@@ -452,7 +546,7 @@ Class PSSerialize {
             elseif ($Expression -is [Char])        { $Expression = "'$Value'" }
             elseif ($Expression -is [ScriptBlock]) { $Expression = $Expression.Ast.Extent.Text }
             elseif ($Expression -is [HashTable])   { $Expression = '@{}' }
-            elseif ($Expression -is [array]) {
+            elseif ($Expression -is [Array]) {
                 $Space = if ($this.ExpandDepth -ge 0) { ' ' }
                 $New = if ($TypeInitializer) { '::new(' } else { '@(' }
                 $Expression = $New + ($Expression.foreach{
@@ -507,14 +601,17 @@ Class PSSerialize {
                         $Separator = if ($this.ExpandDepth -ge 0) { '; ' } else { ';' }
                         $this.NewWord($Separator)
                     }
-                    elseif ($ExpandSingle) { $this.NewWord() }
-                    elseif ($this.ExpandDepth -ge 0) { $this.StringBuilder.Append(' ') }
-                    $this.StringBuilder.Append($_.Name)
+                    elseif ($this.ExpandDepth -ge 0) {
+                        if ($ExpandSingle) { $this.NewWord() } else { $this.StringBuilder.Append(' ') }
+                    }
+                    $Key = [PSKeyExpression]::new($_.Name, $this.LanguageMode, ($this.ExpandDepth -lt 0))
+                    $this.StringBuilder.Append($Key)
                     if ($this.ExpandDepth -ge 0) { $this.StringBuilder.Append(' = ') } else { $this.StringBuilder.Append('=') }
                     $this.Iterate($_)
                 }
                 $this.Offset--
-                if ($this.LineNumber -gt $StartLine) { $this.NewWord() } else { $this.StringBuilder.Append(' ') }
+                if ($this.LineNumber -gt $StartLine) { $this.NewWord() }
+                elseif ($this.ExpandDepth -ge 0) { $this.StringBuilder.Append(' ') }
                 $this.StringBuilder.Append('}')
             }
             elseif ($Node -is [PSObjectNode] -and $TypeInitializer) { $this.StringBuilder.Append('::new()') }
@@ -536,11 +633,19 @@ Class PSSerialize {
         }
     }
 
-    hidden [String]Quote($Value) { return "'" + "$Value".Replace("'", "''") + "'" }
-
     [String] ToString() {
         return $this.StringBuilder.ToString()
     }
+ }
+
+ Class PSStringify : PSSerialize {
+    hidden static [int]$MaximumListCount    = 3
+    hidden static [int]$MaximumMapCount     = 3
+    hidden static [int]$MaximumStringLength = 48
+    hidden static [int]$MaximumKeyLength    = 12
+    hidden static [int]$MaximumValueLength  = 16
+
+    PSStringify($Object) { $this.Serialize($Object) }
  }
 
 #  ____  ____  ____                      _       _ _
@@ -549,7 +654,7 @@ Class PSSerialize {
 # |  __/ ___) | |_| |  __/\__ \  __/ |  | | (_| | | |/ /  __/
 # |_|   |____/|____/ \___||___/\___|_|  |_|\__,_|_|_/___\___|
 
- Class PSDeserialize {
+Class PSDeserialize {
     hidden static [String[]]$Parameters = 'LanguageMode', 'ArrayType', 'HashTableType'
     hidden static PSDeserialize() { Use-ClassAccessors }
 
@@ -560,29 +665,17 @@ Class PSSerialize {
     [String] $Expression
 
     PSDeserialize([String]$Expression) { $this.Expression = $Expression }
-    PSDeserialize([String]$Expression, [PSLanguageMode]$LanguageMode) {
-        $this.Expression = $Expression
-        if ($this.LanguageMode -eq 'NoLanguage') { Throw 'The language mode "NoLanguage" is not supported.' }
-        $this.LanguageMode = $LanguageMode
-    }
     PSDeserialize(
         $Expression,
         $LanguageMode  = 'Restricted',
-        $ArrayType,
-        $HashTableType
+        $ArrayType     = $Null,
+        $HashTableType = $Null
     ) {
+        if ($this.LanguageMode -eq 'NoLanguage') { Throw 'The language mode "NoLanguage" is not supported.' }
         $this.Expression    = $Expression
         $this.LanguageMode  = $LanguageMode
         if ($Null -ne $ArrayType)     { $this.ArrayType     = $ArrayType }
         if ($Null -ne $HashTableType) { $this.HashTableType = $HashTableType }
-    }
-
-    PSDeserialize($Expression, [HashTable]$Parameters) {
-        $this.Expression = $Expression
-        foreach ($Name in $Parameters.get_Keys()) { # https://github.com/PowerShell/PowerShell/issues/13307
-            if ($Name -notin [PSSerialize]::Parameters) { Throw "Unknown parameter: $Name." }
-            $this.GetType().GetProperty($Name).SetValue($this, $Parameters[$Name])
-        }
     }
 
     hidden [Object] get_Object() {
@@ -601,7 +694,7 @@ Class PSSerialize {
             if (
                 $this.LanguageMode -eq 'Full' -or (
                     $this.LanguageMode -eq 'Constrained' -and
-                    [LanguageType]::IsConstrained($FullTypeName)
+                    $Global:PSLanguageType.IsConstrained($FullTypeName)
                 )
             ) {
                 try { $Type = $FullTypeName -as [Type] } catch { write-error $_ }
@@ -616,10 +709,13 @@ Class PSSerialize {
             if ($List.Count -eq 1) { return $List[0] } else { return @($List) }
         }
         elseif ($Ast -is [PipelineAst]) {
-            $Element = $Ast.PipelineElements.Expression
-                if ($Element.Count -eq 0) { return @() }
-            elseif ($Element.Count -eq 1) { return $this.ParseAst($Element[0]) }
-            else                          { return $Element.Foreach{ $this.ParseAst($_) } }
+            $Elements = $Ast.PipelineElements
+            if (-not $Elements.Count)  { return @() }
+            elseif ($Elements -is [CommandAst]) {
+                return $Null #85 ConvertFrom-Expression: convert function/cmdlet calls to Objects
+            }
+            elseif ($Elements.Expression.Count -eq 1) { return $this.ParseAst($Elements.Expression[0]) }
+            else { return $Elements.Expression.Foreach{ $this.ParseAst($_) } }
         }
         elseif ($Ast -is [ArrayLiteralAst] -or $Ast -is [ArrayExpressionAst]) {
             if (-not $Type -or 'System.Object[]', 'System.Array' -eq $Type.FullName) { $Type = $this.ArrayType }
@@ -653,10 +749,12 @@ Class PSSerialize {
         }
         elseif ($Ast -is [VariableExpressionAst]) {
             $Value = switch ($Ast.VariablePath.UserPath) {
-                Null    { $Null }
-                True    { $True }
-                False   { $False }
-                Default { $Ast.Extent.Text }
+                Null        { $Null }
+                True        { $True }
+                False       { $False }
+                PSCulture   { (Get-Culture).ToString() }
+                PSUICulture { (Get-UICulture).ToString() }
+                Default     { $Ast.Extent.Text }
             }
             return $Value
         }
@@ -664,11 +762,11 @@ Class PSSerialize {
     }
 }
 
- #   __  __   _
- #   \ \/ /__| |_ __
- #    \  // _` | '_ \
- #    /  \ (_| | | | |
- #   /_/\_\__,_|_| |_|
+#   __  __   _
+#   \ \/ /__| |_ __
+#    \  // _` | '_ \
+#    /  \ (_| | | | |
+#   /_/\_\__,_|_| |_|
 
 enum XdnType { Root; Ancestor; Index; Child; Descendant; Equals; Error = 99 }
 
@@ -694,47 +792,60 @@ class XdnColor {
     }
 }
 
-class XdnValue {
-    hidden static $Verbatim = '^[\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}_][\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}\p{Nd}_]*$' # https://stackoverflow.com/questions/62754771/unquoted-key-rules-and-best-practices
-    hidden [Bool]$_IsLiteral
-    hidden $_IsWildcard
+class XdnName {
+    hidden [Bool]$_Literal
+    hidden $_IsVerbatim
+    hidden $_ContainsWildcard
     hidden $_Value
 
-    XdnValue($Value) {
-        $this._IsLiteral = $False
-        $this._IsWildcard = $Null
-        $this._Value = $Value -replace '(?<=[^`](``)*)`(?=[\.\[\~\=\/])' # Remove any (odd number of) escapes from Xdn operators
-    }
-
-    XdnValue($Value, [Bool]$Literal) {
-        $this._IsLiteral = $Literal
-        $this._IsWildcard = $False
+    hidden Initialize($Value, $Literal) {
         $this._Value = $Value
+        if ($Null -ne $Literal) { $this._Literal = $Literal } else { $this._Literal = $this.IsVerbatim() }
+        if ($this._Literal) {
+            $XdnName = [XdnName]::new()
+            $XdnName._ContainsWildcard = $False
+         }
+        else {
+            $XdnName = [XdnName]::new()
+            $XdnName._ContainsWildcard = $null
+        }
+
+    }
+    XdnName() {}
+    XdnName($Value)                    { $this.Initialize($Value, $null) }
+    XdnName($Value, [Bool]$Literal)    { $this.Initialize($Value, $Literal) }
+    static [XdnName]Literal($Value)    { return [XdnName]::new($Value, $true) }
+    static [XdnName]Expression($Value) { return [XdnName]::new($Value, $false) }
+
+    [Bool] IsVerbatim() {
+        if ($Null -eq $this._IsVerbatim) {
+            $this._IsVerbatim = $this._Value -is [String] -and $this._Value -Match '^[\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}_][\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}\p{Nd}_]*$' # https://stackoverflow.com/questions/62754771/unquoted-key-rules-and-best-practices
+        }
+        return $this._IsVerbatim
     }
 
-    [Bool] IsWildcard() {
-        if ($this._IsLiteral) { $this._IsWildcard = $False }
-        elseif ($Null -eq $this._IsWildcard) {
-            $this._IsWildcard = $this._Value -is [String] -and $this._Value -Match '(?<=([^`]|^)(``)*)[\?\*]'
+    [Bool] ContainsWildcard() {
+        if ($Null -eq $this._ContainsWildcard) {
+            $this._ContainsWildcard = $this._Value -is [String] -and $this._Value -Match '(?<=([^`]|^)(``)*)[\?\*]'
         }
-        return $this._IsWildcard
+        return $this._ContainsWildcard
     }
 
     [Bool] Equals($Object) {
-        if ($this._IsLiteral)       { return $this._Value -eq $Object }
-        elseif ($this.IsWildcard()) { return $Object -Like $this._Value }
-        else                        { return $this._Value -eq $Object }
+        if ($this._Literal)               { return $this._Value -eq $Object }
+        elseif ($this.ContainsWildcard()) { return $Object -Like $this._Value }
+        else                              { return $this._Value -eq $Object }
     }
 
     [String] ToString($Colored) {
         $Color = if ($Colored) {
-            if ($this._IsLiteral)                                { [XdnColor]::Regular }
-            elseif ($this._Value -NotMatch [XdnValue]::Verbatim) { [XdnColor]::Extended }
-            elseif ($this.IsWildcard())                          { [XdnColor]::Wildcard }
-            else                                                 { [XdnColor]::Regular }
+            if ($this._Literal)               { [XdnColor]::Regular }
+            elseif (-not $this.IsVerbatim())  { [XdnColor]::Extended }
+            elseif ($this.ContainsWildcard()) { [XdnColor]::Wildcard }
+            else                              { [XdnColor]::Regular }
         }
         $String =
-            if ($this._IsLiteral) { "'" + "$($this._Value)".Replace("'", "''") + "'" }
+            if ($this._Literal) { "'" + "$($this._Value)".Replace("'", "''") + "'" }
             else { "$($this._Value)" -replace '(?<!([^`]|^)(``)*)[\.\[\~\=\/]', '`${0}' } # Escape any Xdn operator (that isn't yet escaped)
         $Reset = if ($Colored) { [XdnColor]::Reset }
         return $Color + $String + $Reset
@@ -742,18 +853,28 @@ class XdnValue {
     [String] ToString()        { return $this.ToString($False) }
     [String] ToColoredString() { return $this.ToString($True) }
 
-    static XdnValue() {
+    static XdnName() {
         Set-View { $_.ToString($True) }
     }
 }
-
 class XdnPath {
     hidden static $_PSReadLineOption
-    hidden static $Verbatim = '^[\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}_][\?\*\p{L}\p{Lt}\p{Lm}\p{Lo}\p{Nd}_]*$' # https://stackoverflow.com/questions/62754771/unquoted-key-rules-and-best-practices
 
     hidden $_Entries = [List[KeyValuePair[XdnType, Object]]]::new()
 
     hidden [Object]get_Entries() { return ,$this._Entries }
+
+    XdnPath ([String]$Path)                 { $this.FromString($Path, $False) }
+    XdnPath ([String]$Path, [Bool]$Literal) { $this.FromString($Path, $Literal) }
+    XdnPath ([PSNodePath]$Path) {
+        foreach ($Node in $Path.Nodes) {
+            Switch ($Node.NodeOrigin) {
+                Root { $this.Add('Root',  $Null) }
+                List { $this.Add('Index', $Node.Name) }
+                Map  { $this.Add('Child', [XdnName]$Node.Name) }
+            }
+        }
+    }
 
     hidden AddError($Value) {
         $this._Entries.Add([KeyValuePair[XdnType, Object]]::new('Error', $Value))
@@ -797,11 +918,11 @@ class XdnPath {
                 $Ast = [Parser]::ParseInput($Path, [ref]$Null, [ref]$Null)
                 $StringAst = $Ast.EndBlock.Statements.Find({ $args[0] -is [StringConstantExpressionAst] }, $False)
                 if ($Null -ne $StringAst) {
-                    $this.Add($XdnOperator, [XdnValue]::new($StringAst[0].Value, $True))
+                    $this.Add($XdnOperator, [XdnName]::Literal($StringAst[0].Value))
                     $Path = $Path.SubString($StringAst[0].Extent.EndOffset)
                 }
                 else { # Probably a quoting error
-                    $this.Add($XdnOperator, [XdnValue]::new($Path, $True))
+                    $this.Add($XdnOperator, [XdnName]::Literal($Path, $True))
                     $Path = $Null
                 }
             }
@@ -837,21 +958,19 @@ class XdnPath {
                 elseif ($Match.Success) {
                     if (-not $XdnOperator) { $XdnOperator = 'Child' }
                     $Name = $Path.SubString(0, $Match.Index)
-                    $Value = if ($Literal) { [XdnValue]::new($Name, $True) } else { [XdnValue]$Name }
+                    $Value = if ($Literal) { [XdnName]::Literal($Name) } else { [XdnName]::Expression($Name) }
                     $this.Add($XdnOperator, $Value)
                     $Path = $Path.SubString($Match.Index)
                     $XdnOperator = $Null
                 }
                 else {
-                    $Value = if ($Literal) { [XdnValue]::new($Path, $True) } else { [XdnValue]$Path }
+                    $Value = if ($Literal) { [XdnName]::Literal($Path) } else { [XdnName]::Expression($Path)}
                     $this.Add($XdnOperator, $Value)
                     $Path = $Null
                 }
             }
         }
     }
-    XdnPath ([String]$Path)                 { $this.FromString($Path, $False) }
-    XdnPath ([String]$Path, [Bool]$Literal) { $this.FromString($Path, $Literal) }
 
     [String] ToString([String]$VariableName, [Bool]$Colored) {
         $RegularColor  = if ($Colored) { [XdnColor]::Regular }
@@ -892,6 +1011,7 @@ class XdnPath {
     }
 }
 
+enum PSNodeStructure { Leaf; List; Map }
 enum PSNodeOrigin { Root; List; Map }
 
 Class PSNodePath {
@@ -904,21 +1024,36 @@ Class PSNodePath {
         return "$Path" + $String
     }
 
+    [Bool] Equals([Object]$Path) {
+        if ($Path -is [PSNodePath]) {
+            if ($this.Nodes.Count -ne $Path.Nodes.Count) { return $false }
+            $Index = 0
+            foreach( $Node in $this.Nodes) {
+                if ($Node.NodeOrigin -ne $Path.Nodes[$Index].NodeOrigin -or
+                    $Node.Name       -ne $Path.Nodes[$Index].Name
+                ) { return $false }
+                $Index++
+            }
+            return $true
+        }
+        elseif ($Path -is [String]) {
+            return $this.ToString() -eq $Path
+        }
+        return $false
+    }
+
     [String] ToString() {
         if ($Null -eq $this._String) {
             $Count = $this.Nodes.Count
             $this._String = if ($Count -gt 1) { $this.Nodes[-2].Path.ToString() }
             $Node = $this.Nodes[-1]
-            $this._String +=
-                if ($Node._NodeOrigin -eq 'List') {
+            $this._String += # Copy the new path into the current node
+                if ($Node.NodeOrigin -eq 'List') {
                     "[$($Node._Name)]"
                 }
-                elseif ($Node._NodeOrigin -eq 'Map') {
-                    $Dot = if ($Count -gt 2) { '.' }
-                    if     ($Node.Name -is [ValueType])        { "$Dot$($Node._Name)" }
-                    elseif ($Node.Name -isnot [String])        { "$Dot[$($Node._Name.GetType())]'$($Node._Name)'" }
-                    elseif ($Node.Name -Match '^[_,a-z]+\w*$') { "$Dot$($Node._Name)" }
-                    else                                       { "$Dot'$($Node._Name)'" }
+                elseif ($Node.NodeOrigin -eq 'Map') {
+                    $KeyExpression = [PSKeyExpression]$Node._Name
+                    if ($Count -le 2) { $KeyExpression } else { ".$KeyExpression" }
                 }
         }
         return $this._String
@@ -932,42 +1067,71 @@ Class PSNodePath {
 #    |  __/ ___) | |\  | (_) | (_| |  __/
 #    |_|   |____/|_| \_|\___/ \__,_|\___|
 
-Class PSNode {
+Class PSNode : IComparable {
     hidden static PSNode() { Use-ClassAccessors }
 
     static [int]$DefaultMaxDepth = 20
+
     hidden $_Name
     [Int]$Depth
     hidden $_Value
     hidden [Int]$_MaxDepth = [PSNode]::DefaultMaxDepth
-    hidden [PSNodeOrigin]$_NodeOrigin
     [PSNode]$ParentNode
     [PSNode]$RootNode = $this
-    hidden [PSNodePath]$_Path
-    hidden [String]$_PathName
+    # hidden [PSNodePath]$_Path
+    # hidden [String]$_PathName
+    hidden [Dictionary[String,Object]]$Cache = [Dictionary[String,Object]]::new()
     hidden [DateTime]$MaxDepthWarningTime            # Warn ones per item branch
 
-    hidden [object] get_Value() {
-        return ,$this._Value
+    static [PSNode] ParseInput($Object, $MaxDepth) {
+        $Node =
+            if ($Object -is [PSNode]) { $Object }
+            else {
+                if     ($Null -eq $Object)                                  { [PSLeafNode]::new($Object) }
+                elseif ($Object -is [Management.Automation.PSCustomObject]) { [PSObjectNode]::new($Object) }
+                elseif ($Object -is [Collections.IDictionary])              { [PSDictionaryNode]::new($Object) }
+                elseif ($Object -is [Specialized.StringDictionary])         { [PSDictionaryNode]::new($Object) }
+                elseif ($Object -is [Collections.ICollection])              { [PSListNode]::new($Object) }
+                elseif ($Object -is [ValueType])                            { [PSLeafNode]::new($Object) }
+                elseif ($Object -is [String])                               { [PSLeafNode]::new($Object) }
+                elseif ($Object -is [ScriptBlock])                          { [PSLeafNode]::new($Object) }
+                elseif ($Object.PSObject.Properties)                        { [PSObjectNode]::new($Object) }
+                else                                                        { [PSLeafNode]::new($Object) }
+            }
+        $Node.RootNode = $Node
+        if ($MaxDepth -gt 0) { $Node._MaxDepth = $MaxDepth }
+        return $Node
     }
+
+    static [PSNode] ParseInput($Object) { return [PSNode]::parseInput($Object, 0) }
+
+    static [int] Compare($Left, $Right) {
+        return [ObjectComparer]::new().Compare($Left, $Right)
+    }
+    static [int] Compare($Left, $Right, [String[]]$PrimaryKey) {
+        return [ObjectComparer]::new($PrimaryKey, 0, [CultureInfo]::CurrentCulture).Compare($Left, $Right)
+    }
+    static [int] Compare($Left, $Right, [String[]]$PrimaryKey, [ObjectComparison]$ObjectComparison) {
+        return [ObjectComparer]::new($PrimaryKey, $ObjectComparison, [CultureInfo]::CurrentCulture).Compare($Left, $Right)
+    }
+    static [int] Compare($Left, $Right, [String[]]$PrimaryKey, [ObjectComparison]$ObjectComparison, [CultureInfo]$CultureInfo) {
+       return [ObjectComparer]::new($PrimaryKey, $ObjectComparison, $CultureInfo).Compare($Left, $Right)
+    }
+
+    hidden [object] get_Value() { return ,$this._Value }
 
     hidden set_Value($Value) {
-        if ($this.GetType().Name -eq [PSNode]::getPSNodeType($Value)) { # The root node is of type PSNode (always false)
-            $this._Value = $Value
-            $this.ParentNode.SetItem($this._Name,  $Value)
-        }
-        else {
-            Throw "The supplied value has a different PSNode type than the existing $($this.Path). Use .ParentNode.SetItem() method and reload its child item(s)."
+        $this.Cache.Clear()
+        $this._Value = $Value
+        if ($Null -ne $this.ParentNode) { $this.ParentNode.SetItem($this._Name,  $Value) }
+        if ($this.GetType() -ne [PSNode]::ParseInput($Value).GetType()) { # The root node is of type PSNode (always false)
+            Write-Warning "The supplied value has a different PSNode type than the existing $($this.Path). Use .ParentNode.SetItem() method and reload its child item(s)."
         }
     }
 
-    hidden [Object] get_Name() {
-        return ,$this._Name
-    }
+    hidden [Object] get_Name() { return ,$this._Name }
 
-    hidden [Object] get_MaxDepth() {
-        return $this.RootNode._MaxDepth
-    }
+    hidden [Object] get_MaxDepth() { return $this.RootNode._MaxDepth }
 
     hidden set_MaxDepth($MaxDepth) {
         if (-not $this.ChildType) {
@@ -978,69 +1142,39 @@ Class PSNode {
         }
     }
 
-    hidden [Object] get_NodeOrigin()  { return [PSNodeOrigin]$this._NodeOrigin }
+    hidden [PSNodeStructure] get_NodeStructure()  {
+        if ($this -is [PSListNode]) { return 'List' } elseif ($this -is [PSMapNode]) { return 'Map' } else { return 'Leaf' }
+    }
+
+    hidden [PSNodeOrigin] get_NodeOrigin()  {
+        if ($this.ParentNode -is [PSListNode]) { return 'List' } elseif ($this.ParentNode -is [PSMapNode]) { return 'Map' } else { return 'Root' }
+    }
 
     hidden [Type] get_ValueType() {
         if ($Null -eq $this._Value) { return $Null }
         else { return $this._Value.getType() }
     }
 
-    hidden static [String]GetPSNodeType($Object) {
-        if ($Null -eq $Object)                                      { return 'PSLeafNode' }
-        elseif ($Object -is [Management.Automation.PSCustomObject]) { return 'PSObjectNode' }
-        elseif ($Object -is [Collections.IDictionary])              { return 'PSDictionaryNode' }
-        elseif ($Object -is [Specialized.StringDictionary])         { return 'PSDictionaryNode' }
-        elseif ($Object -is [Collections.ICollection])              { return 'PSListNode' }
-        elseif ($Object -is [ValueType])                            { return 'PSLeafNode' }
-        elseif ($Object -is [String])                               { return 'PSLeafNode' }
-        elseif ($Object -is [ScriptBlock])                          { return 'PSLeafNode' }
-        elseif ($Object.PSObject.Properties)                        { return 'PSObjectNode' }
-        else                                                        { return 'PSLeafNode' }
-    }
-
-    static [PSNode] ParseInput($Object, $MaxDepth) {
-        $Node =
-            if ($Object -is [PSNode]) { $Object }
-            else {
-                switch ([PSNode]::getPSNodeType($object)) {
-                    'PSObjectNode'     { [PSObjectNode]::new($Object) }
-                    'PSDictionaryNode' { [PSDictionaryNode]::new($Object) }
-                    'PSListNode'       { [PSListNode]::new($Object) }
-                    Default            { [PSLeafNode]::new($Object) }
-                }
-            }
-        $Node.RootNode  = $Node
-        if ($MaxDepth -gt 0) { $Node._MaxDepth = $MaxDepth }
-        return $Node
-    }
-
-    static [PSNode] ParseInput($Object) { return [PSNode]::parseInput($Object, 0) }
-
+    [Int]GetHashCode() { return $this.GetHashCode($false) } # Ignore the case of a string value
 
     hidden [PSNode] Append($Object) {
         $Node = [PSNode]::ParseInput($Object)
         $Node.Depth       = $this.Depth + 1
         $Node.RootNode    = [PSNode]$this.RootNode
         $Node.ParentNode  = $this
-        $Node._NodeOrigin = if ($this -is [PSListNode]) { 'List' } elseif ($this -is [PSMapNode]) { 'Map' }
         return $Node
     }
 
     hidden [Object] get_Path() {
-        if ($Null -eq $this._Path) {
+        if (-not $this.Cache.ContainsKey('Path')) {
             if ($this.ParentNode) {
-                $this._Path = [PSNodePath]($this.ParentNode.get_Path().Nodes + $this)
+                $this.Cache['Path'] = [PSNodePath]($this.ParentNode.get_Path().Nodes + $this)
             }
             else {
-                $this._Path = [PSNodePath]$this
+                $this.Cache['Path'] = [PSNodePath]$this
             }
         }
-        return $this._Path
-    }
-
-    hidden [String] get_PathName() {
-        # Write-Warning 'The `PathName` property has been deprecated. Use the [String]$Node.Path property or the $Node.GetPathName(''$Object'') method instead.'
-        return $this.get_Path().ToString()
+        return $this.Cache['Path']
     }
 
     [String] GetPathName($VariableName) {
@@ -1054,6 +1188,20 @@ Class PSNode {
     }
 
     [String] GetPathName() { return $this.get_Path().ToString() }
+
+    [Bool] Equals($Object)  {  # https://learn.microsoft.com/dotnet/api/system.globalization.compareoptions
+        if ($Object -is [PSNode]) { $Node = $Object }
+        else { $Node = [PSNode]::ParseInput($Object) }
+        $ObjectComparer = [ObjectComparer]::new()
+        return $ObjectComparer.IsEqual($this, $Node)
+    }
+
+    [int] CompareTo($Object)  {
+        if ($Object -is [PSNode]) { $Node = $Object }
+        else { $Node = [PSNode]::ParseInput($Object) }
+        $ObjectComparer = [ObjectComparer]::new()
+        return $ObjectComparer.Compare($this, $Node)
+    }
 
     hidden CollectNodes($NodeTable, [XdnPath]$Path, [Int]$PathIndex) {
         $Entry = $Path._Entries[$PathIndex]
@@ -1127,13 +1275,27 @@ Class PSLeafNode : PSNode {
         if ($Object -is [PSNode]) { $this._Value = $Object._Value } else { $this._Value = $Object }
     }
 
-    [Int]GetHashCode() {
-        if ($Null -ne $this._Value) { return $this._Value.GetHashCode() } else { return '$Null'.GetHashCode() }
+    [Int]GetHashCode($CaseSensitive) {
+        if ($Null -eq $this._Value) { return '$Null'.GetHashCode() }
+        if ($CaseSensitive) { return $this._Value.GetHashCode() }
+        else {
+            if ($this._Value -is [String]) { return $this._Value.ToUpper().GetHashCode() } # Windows PowerShell doesn't have a System.HashCode struct
+            else { return $this._Value.GetHashCode() }
+        }
+    }
+
+    [string]ToString() { return $this.ToString($false) }
+    [string]ToString([Bool]$IsChild) {
+        # $MaximumStringLength = if ($IsChild) { [PSNode]::MaximumNodeStringLength } else { [PSNode]::MaximumChildStringLength }
+        return $Null
+
     }
 }
 
 Class PSCollectionNode : PSNode {
     hidden static PSCollectionNode() { Use-ClassAccessors }
+    hidden [Dictionary[bool,int]]$_HashCode # Unlike the value HashCode, the default (bool = $false) node HashCode is case insensitive
+    hidden [Dictionary[bool,int]]$_ReferenceHashCode # if changed, recalculate the (bool = case sensitive) node's HashCode
 
     hidden [bool]MaxDepthReached() {
         # Check whether the max depth has been reached.
@@ -1182,22 +1344,61 @@ Class PSCollectionNode : PSNode {
         return $List
     }
 
-    [List[PSNode]]GetChildNodes($Levels, [PSNodeOrigin]$NodeOrigin, [Bool]$Leaf) {
+    [List[PSNode]]GetNodeList($Levels, [PSNodeOrigin]$NodeOrigin, [Bool]$Leaf) {
         $NodeList = [List[PSNode]]::new()
         $this.CollectChildNodes($NodeList, $Levels, $NodeOrigin, $Leaf)
         return $NodeList
     }
-    [List[PSNode]]GetChildNodes()                                       { return $this.GetChildNodes(0, 0, $False) }
-    [List[PSNode]]GetChildNodes([Int]$Levels)                           { return $this.GetChildNodes($Levels, 0, $False) }
-    [List[PSNode]]GetChildNodes([PSNodeOrigin]$NodeOrigin, [Bool]$Leaf) { return $this.GetChildNodes(0, $NodeOrigin, $Leaf) }
+    [List[PSNode]]GetNodeList()                                       { return $this.GetNodeList(0, 0, $False) }
+    [List[PSNode]]GetNodeList([Int]$Levels)                           { return $this.GetNodeList($Levels, 0, $False) }
+    [List[PSNode]]GetNodeList([PSNodeOrigin]$NodeOrigin, [Bool]$Leaf) { return $this.GetNodeList(0, $NodeOrigin, $Leaf) }
 
-    hidden [PSNode[]]get_ChildNodes()      { return $this.GetChildNodes(0,  0,      $False) }
-    hidden [PSNode[]]get_ListChildNodes()  { return [PSNode[]]$this.GetChildNodes(0,  'List', $False) }
-    hidden [PSNode[]]get_MapChildNodes()   { return [PSNode[]]$this.GetChildNodes(0,  'Map',  $False) }
-    hidden [PSNode[]]get_DescendantNodes() { return $this.GetChildNodes(-1, 0,      $False) }
-    hidden [PSNode[]]get_LeafNodes()       { return $this.GetChildNodes(-1, 0,      $True) }
-    hidden [PSNode]_($Name)                { return $this.GetChildNode($Name) }       # CLI Shorthand ("alias") for GetChildNode (don't use in scripts)
-    # hidden [Object]Get($Path)                { return $this.GetDescendantNode($Path) }  # CLI Shorthand ("alias") for GetDescendantNode (don't use in scripts)
+    hidden [PSNode[]]get_ChildNodes() {
+        # There is no link between the 'ChildNodes' cache and the 'GetChildNode()' function
+        # because the comparer of the contained value collection is unknown and
+        # it is too expensive and ambiguous to linear search for the actual/original key name.
+        # see: https://stackoverflow.com/a/78656228/1701026
+        if (-not $this.Cache.ContainsKey('ChildNodes')) { $this.Cache['ChildNodes'] = [PSNode[]]$this.GetNodeList(0, 0, $False) }
+        return $this.Cache['ChildNodes']
+    }
+
+    #hidden [PSNode[]]get_ChildNodes()      { return $this.GetNodeList(0, 0, $False) }
+    hidden [PSNode[]]get_ListChildNodes()  { return $this.GetNodeList(0, 'List', $False) }
+    hidden [PSNode[]]get_MapChildNodes()   { return $this.GetNodeList(0, 'Map',  $False) }
+    hidden [PSNode[]]get_DescendantNodes() { return $this.GetNodeList(-1, 0, $False) }
+    hidden [PSNode[]]get_LeafNodes()       { return $this.GetNodeList(-1, 0, $True) }
+    # hidden [PSNode]_($Name)                { return $this.GetChildNode($Name) }       # CLI Shorthand ("alias") for GetChildNode (don't use in scripts)
+    # hidden [Object]Get($Path)              { return $this.GetDescendantNode($Path) }  # CLI Shorthand ("alias") for GetDescendantNode (don't use in scripts)
+
+    Sort() { $this.Sort($Null, 0) }
+    Sort([ObjectComparison]$ObjectComparison) { $this.Sort($Null, $ObjectComparison) }
+    Sort([String[]]$PrimaryKey) { $this.Sort($PrimaryKey, 0) }
+    Sort([ObjectComparison]$ObjectComparison, [String[]]$PrimaryKey) { $this.Sort($PrimaryKey, $ObjectComparison) }
+    Sort([String[]]$PrimaryKey, [ObjectComparison]$ObjectComparison) {
+        # As the child nodes are sorted first, we just do a side-by-side node compare:
+        $ObjectComparison = $ObjectComparison -bor [ObjectComparison]'MatchMapOrder'
+        $ObjectComparison = $ObjectComparison -band (-1 - [ObjectComparison]'IgnoreListOrder')
+        $PSListNodeComparer = [PSListNodeComparer]@{ PrimaryKey = $PrimaryKey; ObjectComparison = $ObjectComparison }
+        $PSMapNodeComparer = [PSMapNodeComparer]@{ PrimaryKey = $PrimaryKey; ObjectComparison = $ObjectComparison }
+        $this.SortRecurse($PSListNodeComparer, $PSMapNodeComparer)
+    }
+
+    hidden SortRecurse([PSListNodeComparer]$PSListNodeComparer, [PSMapNodeComparer]$PSMapNodeComparer) {
+        $NodeList = $this.GetNodeList()
+        foreach ($Node in $NodeList) {
+            if ($Node -is [PSCollectionNode]) { $Node.SortRecurse($PSListNodeComparer, $PSMapNodeComparer) }
+        }
+        if ($this -is [PSListNode]) {
+            $NodeList.Sort($PSListNodeComparer)
+            if ($NodeList.Count) { $this._Value = @($NodeList.Value) } else { $this._Value = @() }
+        }
+        else { # if ($Node -is [PSMapNode])
+            $NodeList.Sort($PSMapNodeComparer)
+            $Properties = [System.Collections.Specialized.OrderedDictionary]::new([StringComparer]::Ordinal)
+            foreach($ChildNode in $NodeList) { $Properties[[Object]$ChildNode.Name] = $ChildNode.Value } # [Object] forces a key rather than an index (ArgumentOutOfRangeException)
+            if ($this -is [PSObjectNode]) { $this._Value = [PSCustomObject]$Properties } else { $this._Value = $Properties }
+        }
+    }
 }
 
 Class PSListNode : PSCollectionNode {
@@ -1206,6 +1407,7 @@ Class PSListNode : PSCollectionNode {
     hidden PSListNode($Object) {
         if ($Object -is [PSNode]) { $this._Value = $Object._Value } else { $this._Value = $Object }
     }
+
     hidden [Object]get_Count() {
         return $this._Value.get_Count()
     }
@@ -1256,26 +1458,51 @@ Class PSListNode : PSCollectionNode {
         return $Node
     }
 
-    [Int]GetHashCode() {
-        $HashCode = '@()'.GetHashCode()
-        foreach ($Node in $this.GetChildNodes(-1)) {
-            $HashCode = $HashCode -bxor $Node.GetHashCode()
+    [Int]GetHashCode($CaseSensitive) {
+        # The hash of a list node is equal if all items match the order and the case.
+        # The primary keys and the list type are not relevant
+        if ($null -eq $this._HashCode) {
+            $this._HashCode = [Dictionary[bool,int]]::new()
+            $this._ReferenceHashCode = [Dictionary[bool,int]]::new()
         }
-        # Shift the bits to make the level unique
-        $HashCode = if ($HashCode -band 1) { $HashCode -shr 1 } else { $HashCode -shr 1 -bor 1073741824 }
-        return $HashCode -bxor 0xa5a5a5a5
+        $ReferenceHashCode = $This._value.GetHashCode()
+        if (-not $this._ReferenceHashCode.ContainsKey($CaseSensitive) -or $this._ReferenceHashCode[$CaseSensitive] -ne $ReferenceHashCode) {
+            $this._ReferenceHashCode[$CaseSensitive] = $ReferenceHashCode
+            $HashCode = '@()'.GetHashCode() # Empty lists have a common hash that is not 0
+            $Index = 0
+            foreach ($Node in $this.GetNodeList()) {
+                $HashCode = $HashCode -bxor "$Index.$($Node.GetHashCode($CaseSensitive))".GetHashCode()
+                $index++
+            }
+            $this._HashCode[$CaseSensitive] = $HashCode
+        }
+        return $this._HashCode[$CaseSensitive]
     }
 }
 
 Class PSMapNode : PSCollectionNode {
     hidden static PSMapNode() { Use-ClassAccessors }
 
-    [Int]GetHashCode() {
-        $HashCode = '@{}'.GetHashCode()
-        foreach ($Node in $this.GetChildNodes(-1)) {
-            $HashCode = $HashCode -bxor "$($Node._Name)=$($Node.GetHashCode())".GetHashCode()
+    [Int]GetHashCode($CaseSensitive) {
+        # The hash of a map node is equal if all names and items match the order and the case.
+        # The map type is not relevant
+        if ($null -eq $this._HashCode) {
+            $this._HashCode = [Dictionary[bool,int]]::new()
+            $this._ReferenceHashCode = [Dictionary[bool,int]]::new()
         }
-        return $HashCode
+        $ReferenceHashCode = $This._value.GetHashCode()
+        if (-not $this._ReferenceHashCode.ContainsKey($CaseSensitive) -or $this._ReferenceHashCode[$CaseSensitive] -ne $ReferenceHashCode) {
+            $this._ReferenceHashCode[$CaseSensitive] = $ReferenceHashCode
+            $HashCode = '@{}'.GetHashCode() # Empty maps have a common hash that is not 0
+            $Index = 0
+            foreach ($Node in $this.GetNodeList()) {
+                $Name = if ($CaseSensitive) { $Node._Name } else { $Node._Name.ToUpper() }
+                $HashCode = $HashCode -bxor "$Index.$Name=$($Node.GetHashCode())".GetHashCode()
+                $Index++
+            }
+            $this._HashCode[$CaseSensitive] = $HashCode
+        }
+        return $this._HashCode[$CaseSensitive]
     }
 }
 
@@ -1326,9 +1553,7 @@ Class PSDictionaryNode : PSMapNode {
 
     [Object]GetChildNode($Key) {
         if ($this.MaxDepthReached()) { return $Null }
-        if (-not $this._Value.Contains($Key)) {
-            Throw "The <Object>$($this.Path) doesn't contain a child named: $Key"
-        }
+        if (-not $this._Value.Contains($Key)) { Throw "The <Object>$($this.Path) doesn't contain a child named: $Key" }
         $Node = $this.Append($this._Value[$Key])
         $Node._Name = $Key
         return $Node
@@ -1392,6 +1617,334 @@ Class PSObjectNode : PSMapNode {
     }
 }
 
+
 Update-TypeData -TypeName PSNode -DefaultDisplayPropertySet Path, Name, Depth, Value -Force
 
 
+#      ___  _     _           _    ____
+#     / _ \| |__ (_) ___  ___| |_ / ___|___  _ __ ___  _ __   __ _ _ __ ___ _ __
+#    | | | | '_ \| |/ _ \/ __| __| |   / _ \| '_ ` _ \| '_ \ / _` | '__/ _ \ '__|
+#    | |_| | |_) | |  __/ (__| |_| |__| (_) | | | | | | |_) | (_| | | |  __/ |
+#     \___/|_.__// |\___|\___|\__|\____\___/|_| |_| |_| .__/ \__,_|_|  \___|_|
+#              |__/                                   |_|
+
+enum ObjectCompareMode {
+    Equals  # https://learn.microsoft.com/dotnet/api/system.object.equals
+    Compare # https://learn.microsoft.com/dotnet/api/system.string.compareto
+    Report  # Returns a report with discrepancies
+}
+
+[Flags()] enum ObjectComparison { MatchCase = 1; MatchType = 2; IgnoreListOrder = 4; MatchMapOrder = 8; Descending = 128 }
+
+class ObjectComparer {
+
+    # Report properties (column names)
+    [String]$Name1 = 'Reference'
+    [String]$Name2 = 'InputObject'
+    [String]$Issue = 'Discrepancy'
+
+    [String[]]$PrimaryKey
+    [ObjectComparison]$ObjectComparison
+
+    [Collections.Generic.List[Object]]$Differences
+
+    ObjectComparer () {}
+    ObjectComparer ([String[]]$PrimaryKey) { $this.PrimaryKey = $PrimaryKey }
+    ObjectComparer ([ObjectComparison]$ObjectComparison) { $this.ObjectComparison = $ObjectComparison }
+    ObjectComparer ([String[]]$PrimaryKey, [ObjectComparison]$ObjectComparison) { $this.PrimaryKey = $PrimaryKey; $this.ObjectComparison = $ObjectComparison }
+    ObjectComparer ([ObjectComparison]$ObjectComparison, [String[]]$PrimaryKey) { $this.PrimaryKey = $PrimaryKey; $this.ObjectComparison = $ObjectComparison }
+
+    [bool] IsEqual ($Object1, $Object2) { return $this.Compare($Object1, $Object2, 'Equals') }
+    [int] Compare  ($Object1, $Object2) { return $this.Compare($Object1, $Object2, 'Compare') }
+    [Object] Report ($Object1, $Object2) {
+        $this.Differences = [Collections.Generic.List[Object]]::new()
+        $null = $this.Compare($Object1, $Object2, 'Report')
+        return $this.Differences
+    }
+
+    [Object] Compare($Object1, $Object2, [ObjectCompareMode]$Mode) {
+        if ($Object1 -is [PSNode]) { $Node1 = $Object1 } else { $Node1 = [PSNode]::ParseInput($Object1) }
+        if ($Object2 -is [PSNode]) { $Node2 = $Object2 } else { $Node2 = [PSNode]::ParseInput($Object2) }
+        return $this.CompareRecurse($Node1, $Node2, $Mode)
+    }
+
+    hidden [Object] CompareRecurse([PSNode]$Node1, [PSNode]$Node2, [ObjectCompareMode]$Mode) {
+        $Comparison = $this.ObjectComparison
+        $MatchCase = $Comparison -band 'MatchCase'
+        $EqualType = $true
+
+        if ($Mode -ne 'Compare') { # $Mode -ne 'Compare'
+            if ($MatchCase -and $Node1.ValueType -ne $Node2.ValueType) {
+                if ($Mode -eq 'Equals') { return $false } else { # if ($Mode -eq 'Report')
+                    $this.Differences.Add([PSCustomObject]@{
+                        Path        = $Node2.Path
+                        $this.Issue = 'Type'
+                        $this.Name1 = $Node1.ValueType
+                        $this.Name2 = $Node2.ValueType
+                    })
+                }
+            }
+            if ($Node1 -is [PSCollectionNode] -and $Node2 -is [PSCollectionNode] -and $Node1.Count -ne $Node2.Count) {
+                if ($Mode -eq 'Equals') { return $false } else { # if ($Mode -eq 'Report')
+                    $this.Differences.Add([PSCustomObject]@{
+                        Path        = $Node2.Path
+                        $this.Issue = 'Size'
+                        $this.Name1 = $Node1.Count
+                        $this.Name2 = $Node2.Count
+                    })
+                }
+            }
+        }
+
+        if ($Node1 -is [PSLeafNode] -and $Node2 -is [PSLeafNode]) {
+            $Eq = if ($MatchCase) { $Node1.Value -ceq $Node2.Value } else { $Node1.Value -eq $Node2.Value }
+            Switch ($Mode) {
+                Equals    { return $Eq }
+                Compare {
+                    if ($Eq) { return 1 - $EqualType } # different types results in 1 (-gt)
+                    else {
+                        $Greater = if ($MatchCase) { $Node1.Value -cgt $Node2.Value } else { $Node1.Value -gt $Node2.Value }
+                        if ($Greater -xor $Comparison -band 'Descending') { return 1 } else { return -1 }
+                    }
+                }
+                default {
+                    if (-not $Eq) {
+                        $this.Differences.Add([PSCustomObject]@{
+                            Path        = $Node2.Path
+                            $this.Issue = 'Value'
+                            $this.Name1 = $Node1.Value
+                            $this.Name2 = $Node2.Value
+                        })
+                    }
+                }
+            }
+        }
+        elseif ($Node1 -is [PSListNode] -and $Node2 -is [PSListNode]) {
+            $MatchOrder = -not ($Comparison -band 'IgnoreListOrder')
+            # if ($Node1.GetHashCode($MatchCase) -eq $Node2.GetHashCode($MatchCase)) {
+            #     if ($Mode -eq 'Equals') { return $true } else { return 0 } # Report mode doesn't care about the output
+            # }
+            $Items1 = $Node1.ChildNodes
+            $Items2 = $Node2.ChildNodes
+            if ($Items1.Count) { $Indices1 = [Collections.Generic.List[Int]]$Items1.Name } else { $Indices1 = @() }
+            if ($Items2.Count) { $Indices2 = [Collections.Generic.List[Int]]$Items2.Name } else { $Indices2 = @() }
+            if ($this.PrimaryKey) {
+                $Maps2 = [Collections.Generic.List[Int]]$Items2.where{ $_ -is [PSMapNode] }.Name
+                if ($Maps2.Count) {
+                    $Maps1 = [Collections.Generic.List[Int]]$Items1.where{ $_ -is [PSMapNode] }.Name
+                    if ($Maps1.Count) {
+                        foreach ($Key in $this.PrimaryKey) {
+                            foreach($Index2 in @($Maps2)) {
+                                $Item2 = $Items2[$Index2]
+                                foreach ($Index1 in $Maps1) {
+                                    $Item1 = $Items1[$Index1]
+                                    if ($Item1.GetItem($Key) -eq $Item2.GetItem($Key)) {
+                                        if ($this.CompareRecurse($Item1, $Item2, 'Equals')) {
+                                            $null = $Maps2.Remove($Index2)
+                                            $Null = $Maps1.Remove($Index1)
+                                            $null = $Indices2.Remove($Index2)
+                                            $Null = $Indices1.Remove($Index1)
+                                            break # Only match the first primary key
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        # in case of any single maps leftover without primary keys
+                        if($Maps2.Count -eq 1 -and $Maps1.Count -eq 1) {
+                            $Item2 = $Items2[$Maps2[0]]
+                            $Item1 = $Items1[$Maps1[0]]
+                            $Compare = $this.CompareRecurse($Item1, $Item2, $Mode)
+                            Switch ($Mode) {
+                                Equals  { if (-not $Compare) { return $Compare } }
+                                Compare { if ($Compare)      { return $Compare } }
+                                Default {
+                                    $Maps2.Clear()
+                                    $Maps1.Clear()
+                                    $null = $Indices2.Remove($Maps2[0])
+                                    $Null = $Indices1.Remove($Maps1[0])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (-not $MatchOrder) { # remove the equal nodes from the lists
+                foreach($Index2 in @($Indices2)) {
+                    $Item2 = $Items2[$Index2]
+                    foreach ($Index1 in $Indices1) {
+                        $Item1 = $Items1[$Index1]
+                        if ($this.CompareRecurse($Item1, $Item2, 'Equals')) {
+                            $null = $Indices2.Remove($Index2)
+                            $Null = $Indices1.Remove($Index1)
+                            break # Only match a single node
+                        }
+                    }
+                }
+            }
+            for ($i = 0; $i -lt [math]::max($Indices2.Count, $Indices1.Count); $i++) {
+                $Index1 = if ($i -lt $Indices1.Count) { $Indices1[$i] }
+                $Index2 = if ($i -lt $Indices2.Count) { $Indices2[$i] }
+                $Item1  = if ($Null -ne $Index1) { $Items1[$Index1] }
+                $Item2  = if ($Null -ne $Index2) { $Items2[$Index2] }
+                if ($Null -eq $Item1) {
+                    Switch ($Mode) {
+                        Equals  { return $false }
+                        Compare { return -1 } # None existing items can't be ordered
+                        default {
+                            $this.Differences.Add([PSCustomObject]@{
+                                Path        = $Node2.Path + "[$Index2]"
+                                $this.Issue = 'Exists'
+                                $this.Name1 = $Null
+                                $this.Name2 = if ($Item2 -is [PSLeafNode]) { "$($Item2.Value)" } else { "[$($Item2.ValueType)]" }
+                            })
+                        }
+                    }
+                }
+                elseif ($Null -eq $Item2) {
+                    Switch ($Mode) {
+                        Equals  { return $false }
+                        Compare { return 1 } # None existing items can't be ordered
+                        default {
+                            $this.Differences.Add([PSCustomObject]@{
+                                Path        = $Node1.Path + "[$Index1]"
+                                $this.Issue = 'Exists'
+                                $this.Name1 = if ($Item1 -is [PSLeafNode]) { "$($Item1.Value)" } else { "[$($Item1.ValueType)]" }
+                                $this.Name2 = $Null
+                            })
+                        }
+                    }
+                }
+                else {
+                    $Compare = $this.CompareRecurse($Item1, $Item2, $Mode)
+                    if (($Mode -eq 'Equals' -and -not $Compare) -or ($Mode -eq 'Compare' -and $Compare)) { return $Compare }
+                }
+            }
+            if ($Mode -eq 'Equals') { return $true } elseif ($Mode -eq 'Compare') { return 0 } else { return $null }
+        }
+        elseif ($Node1 -is [PSMapNode] -and $Node2 -is [PSMapNode]) {
+            $MatchOrder = [Bool]($Comparison -band 'MatchMapOrder')
+            if ($MatchOrder -and $Node1._Value -isnot [HashTable] -and $Node2._Value -isnot [HashTable]) {
+                $Items2 = $Node2.ChildNodes
+                $Index = 0
+                foreach ($Item1 in $Node1.ChildNodes) {
+                    if ($Index -lt $Items2.Count) { $Item2 = $Items2[$Index++] } else { break }
+                    $EqualName = if ($MatchCase) { $Item1.Name -ceq $Item2.Name } else { $Item1.Name -eq $Item2.Name }
+                    if ($EqualName) {
+                        $Compare = $this.CompareRecurse($Item1, $Item2, $Mode)
+                        if (($Mode -eq 'Equals' -and -not $Compare) -or ($Mode -eq 'Compare' -and $Compare)) { return $Compare }
+                    }
+                    else {
+                        Switch ($Mode) {
+                            Equals  { return $false }
+                            Compare {} # The order depends on the child name and value
+                            default {
+                                $this.Differences.Add([PSCustomObject]@{
+                                    Path        = $Item1.Path
+                                    $this.Issue = 'Name'
+                                    $this.Name1 = $Item1.Name
+                                    $this.Name2 = $Item2.Name
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+            else {
+                $Found = [HashTable]::new() # (Case sensitive)
+                foreach ($Item2 in $Node2.ChildNodes) {
+                    if ($Node1.Contains($Item2.Name)) {
+                        $Item1 = $Node1.GetChildNode($Item2.Name) # Left defines the comparer
+                        $Found[$Item1.Name] = $true
+                        $Compare = $this.CompareRecurse($Item1, $Item2, $Mode)
+                        if (($Mode -eq 'Equals' -and -not $Compare) -or ($Mode -eq 'Compare' -and $Compare)) { return $Compare }
+                    }
+                    else {
+                        Switch ($Mode) {
+                            Equals  { return $false }
+                            Compare { return -1 }
+                            default {
+                                $this.Differences.Add([PSCustomObject]@{
+                                    Path        = $Item2.Path
+                                    $this.Issue = 'Exists'
+                                    $this.Name1 = $false
+                                    $this.Name2 = $true
+                                })
+                            }
+                        }
+                    }
+                }
+                $Node1.Names.foreach{
+                    if (-not $Found.Contains($_)) {
+                        Switch ($Mode) {
+                            Equals  { return $false }
+                            Compare { return 1 }
+                            default {
+                                $this.Differences.Add([PSCustomObject]@{
+                                    Path        = $Node1.GetChildNode($_).Path
+                                    $this.Issue = 'Exists'
+                                    $this.Name1 = $true
+                                    $this.Name2 = $false
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+            if ($Mode -eq 'Equals') { return $true } elseif ($Mode -eq 'Compare') { return 0 } else { return $null }
+        }
+        else { # Different structure
+            Switch ($Mode) {
+                Equals  { return $false }
+                Compare { # Structure order: PSLeafNode - PSListNode - PSMapNode (can't be reversed)
+                    if ($Node1 -is [PSLeafNode] -or $Node2 -isnot [PSMapNode] ) { return -1 } else { return 1 }
+                }
+                default {
+                    $this.Differences.Add([PSCustomObject]@{
+                        Path        = $Node1.Path
+                        $this.Issue = 'Structure'
+                        $this.Name1 = $Node1.ValueType.Name
+                        $this.Name2 = $Node2.ValueType.Name
+                    })
+                }
+            }
+        }
+        if ($Mode -eq 'Equals')  { throw 'Equals comparison should have returned boolean.' }
+        if ($Mode -eq 'Compare') { throw 'Compare comparison should have returned integer.' }
+        return $null
+    }
+}
+
+class PSListNodeComparer : ObjectComparer, IComparer[Object] { # https://github.com/PowerShell/PowerShell/issues/23959
+    PSListNodeComparer () {}
+    PSListNodeComparer ([String[]]$PrimaryKey) { $this.PrimaryKey = $PrimaryKey }
+    PSListNodeComparer ([ObjectComparison]$ObjectComparison) { $this.ObjectComparison = $ObjectComparison }
+    PSListNodeComparer ([String[]]$PrimaryKey, [ObjectComparison]$ObjectComparison) { $this.PrimaryKey = $PrimaryKey; $this.ObjectComparison = $ObjectComparison }
+    PSListNodeComparer ([ObjectComparison]$ObjectComparison, [String[]]$PrimaryKey) { $this.PrimaryKey = $PrimaryKey; $this.ObjectComparison = $ObjectComparison }
+    [int] Compare ([Object]$Node1, [Object]$Node2) { return $this.CompareRecurse($Node1, $Node2, 'Compare') }
+}
+
+class PSMapNodeComparer : IComparer[Object] {
+    [String[]]$PrimaryKey
+    [ObjectComparison]$ObjectComparison
+
+    PSMapNodeComparer () {}
+    PSMapNodeComparer ([String[]]$PrimaryKey) { $this.PrimaryKey = $PrimaryKey }
+    PSMapNodeComparer ([ObjectComparison]$ObjectComparison) { $this.ObjectComparison = $ObjectComparison }
+    PSMapNodeComparer ([String[]]$PrimaryKey, [ObjectComparison]$ObjectComparison) { $this.PrimaryKey = $PrimaryKey; $this.ObjectComparison = $ObjectComparison }
+    PSMapNodeComparer ([ObjectComparison]$ObjectComparison, [String[]]$PrimaryKey) { $this.PrimaryKey = $PrimaryKey; $this.ObjectComparison = $ObjectComparison }
+    [int] Compare ([Object]$Node1, [Object]$Node2) {
+        $Comparison = $this.ObjectComparison
+        $MatchCase = $Comparison -band 'MatchCase'
+        $Equal = if ($MatchCase) { $Node1.Name -ceq $Node2.Name } else { $Node1.Name -eq $Node2.Name }
+        if ($Equal) { return 0 }
+        else {
+            if ($this.PrimaryKey) {                                           # Primary keys take always priority
+                if ($this.PrimaryKey -eq $Node1.Name) { return -1 }
+                if ($this.PrimaryKey -eq $Node2.Name) { return 1 }
+            }
+            $Greater = if ($MatchCase) { $Node1.Name -cgt $Node2.Name } else { $Node1.Name -gt $Node2.Name }
+            if ($Greater -xor $Comparison -band 'Descending') { return 1 } else { return -1 }
+        }
+    }
+}

--- a/Source/Public/Compare-ObjectGraph.ps1
+++ b/Source/Public/Compare-ObjectGraph.ps1
@@ -41,18 +41,22 @@
         '1.0' -eq 1.0 # $false
         1.0 -eq '1.0' # $true (also $false if the `-MatchType` is provided)
 
-.PARAMETER MatchOrder
-    By default, items in a list and dictionary (including properties of an PSCustomObject or Component Object)
-    are matched independent of the order. If the `-MatchOrder` switch is supplied the index of the concerned
-    item (or property) is matched.
+.PARAMETER IgnoreLisOrder
+    By default, items in a list are matched independent of the order (meaning by index position).
+    If the `-IgnoreListOrder` switch is supplied, any list in the `$InputObject` is searched for a match
+    with the reference.
 
     > [!NOTE]
-    > A `[HashTable]` type is unordered by design and therefore, regardless the `-MatchOrder` switch, the order
-    > of the `[HashTable]` are always ignored.
+    > Regardless the list order, any dictionary lists are matched by the primary key (if supplied) first.
+
+.PARAMETER MatchMapOrder
+    By default, items in dictionary (including properties of an PSCustomObject or Component Object) are
+    matched by their key name (independent of the order).
+    If the `-MatchMapOrder` switch is supplied, each entry is also validated by the position.
 
     > [!NOTE]
-    > Regardless of the `-MatchOrder` switch, indexed (defined by the [PrimaryKey] parameter) dictionaries
-    (including PSCustomObject or Component Objects) in a list are matched independent of the order.
+    > A `[HashTable]` type is unordered by design and therefore, regardless the `-MatchMapOrder` switch,
+    the order of the `[HashTable]` (defined by the `$Reference`) are always ignored.
 
 .PARAMETER MaxDepth
     The maximal depth to recursively compare each embedded property (default: 10).
@@ -74,211 +78,26 @@ function Compare-ObjectGraph {
 
         [Switch]$MatchType,
 
-        [Switch]$MatchOrder,
+        [Switch]$IgnoreListOrder,
+
+        [Switch]$MatchMapOrder,
 
         [Alias('Depth')][int]$MaxDepth = [PSNode]::DefaultMaxDepth
     )
     begin {
-        function CompareObject(
-            [PSNode]$ReferenceNode,
-            [PSNode]$ObjectNode,
-            [String[]]$PrimaryKey = $PrimaryKey,
-            [Switch]$IsEqual      = $IsEqual,
-            [Switch]$MatchCase    = $MatchCase,
-            [Switch]$MatchType    = $MatchType,
-            [Switch]$MatchOrder   = $MatchOrder
-        ) {
-            if ($MatchType) {
-                if ($ObjectNode.ValueType -ne $ReferenceNode.ValueType) {
-                    if ($IsEqual) { return $false }
-                    [PSCustomObject]@{
-                        Path        = $ObjectNode.PathName
-                        Discrepancy = 'Type'
-                        InputObject = $ObjectNode.ValueType
-                        Reference   = $ReferenceNode.ValueType
-                    }
-                }
+        $ObjectComparison = [ObjectComparison]0
+        [ObjectComparison].GetEnumNames().foreach{
+            if ($PSBoundParameters.ContainsKey($_) -and $PSBoundParameters[$_]) {
+                $ObjectComparison = $ObjectComparison -bor [ObjectComparison]$_
             }
-            if ($ObjectNode -is [PSCollectionNode] -and $ReferenceNode -is [PSCollectionNode]) {
-                if ($ObjectNode.Count -ne $ReferenceNode.Count) {
-                    if ($IsEqual) { return $false }
-                    [PSCustomObject]@{
-                        Path        = $ObjectNode.PathName
-                        Discrepancy = 'Size'
-                        InputObject = $ObjectNode.Count
-                        Reference   = $ReferenceNode.Count
-                    }
-                }
-            }
-            if ($ObjectNode -is [PSLeafNode] -and $ReferenceNode -is [PSLeafNode]) {
-                $NotEqual = if ($MatchCase) { $ReferenceNode.Value -cne $ObjectNode.Value } else { $ReferenceNode.Value -ne $ObjectNode.Value }
-                if ($NotEqual) { # $ReferenceNode dictates the type
-                    if ($IsEqual) { return $false }
-                    [PSCustomObject]@{
-                        Path        = $ObjectNode.PathName
-                        Discrepancy = 'Value'
-                        InputObject = $ObjectNode.Value
-                        Reference   = $ReferenceNode.Value
-                    }
-                }
-            }
-            elseif ($ObjectNode -is [PSListNode] -and $ReferenceNode -is [PSListNode]) {
-                $ObjectItems      = $ObjectNode.ChildNodes
-                $ReferenceItems   = $ReferenceNode.ChildNodes
-                if ($ObjectItems.Count)    { $ObjectIndices    = [Collections.Generic.List[Int]]$ObjectItems.Name } else { $ObjectIndices      = @() }
-                if ($ReferenceItems.Count) { $ReferenceIndices = [Collections.Generic.List[Int]]$ReferenceItems.Name } else { $ReferenceIndices = @() }
-                if ($PrimaryKey) {
-                    $ObjectDictionaries = [Collections.Generic.List[Int]]$ObjectItems.where{ $_ -is [PSMapNode] }.Name
-                    if ($ObjectDictionaries.Count) {
-                        $ReferenceDictionaries = [Collections.Generic.List[Int]]$ReferenceItems.where{ $_ -is [PSMapNode] }.Name
-                        if ($ReferenceDictionaries.Count) {
-                            foreach ($Key in $PrimaryKey) {
-                                foreach($ObjectIndex in @($ObjectDictionaries)) {
-                                    $ObjectItem = $ObjectItems[$ObjectIndex]
-                                    foreach ($ReferenceIndex in $ReferenceDictionaries) {
-                                        $ReferenceItem = $ReferenceItems[$ReferenceIndex]
-                                        if ($ReferenceItem.GetItem($Key) -eq $ObjectItem.GetItem($Key)) {
-                                            if (CompareObject -Reference $ReferenceItem -Object $ObjectItem -IsEqual) {
-                                                $null = $ObjectDictionaries.Remove($ObjectIndex)
-                                                $Null = $ReferenceDictionaries.Remove($ReferenceIndex)
-                                                $null = $ObjectIndices.Remove($ObjectIndex)
-                                                $Null = $ReferenceIndices.Remove($ReferenceIndex)
-                                                break # Only match a single node
-                                            }
-                                        }
-                                    }
-                                }
-                                foreach ($Key in $PrimaryKey) { # in case of any single leftovers where the key value doesn't match
-                                    if($ObjectDictionaries.Count -eq 1 -and $ReferenceDictionaries.Count -eq 1) {
-                                        $ObjectItem    = $ObjectItems[$ObjectDictionaries[0]]
-                                        $ReferenceItem = $ReferenceItems[$ReferenceDictionaries[0]]
-                                        $Compare = CompareObject -Reference $ReferenceItem -Object $ObjectItem
-                                        if ($Compare -eq $false) { return $Compare } elseif ($Compare -ne $true) { $Compare }
-                                        $ObjectDictionaries.Clear()
-                                        $ReferenceDictionaries.Clear()
-                                        $null = $ObjectIndices.Remove($ObjectDictionaries[0])
-                                        $Null = $ReferenceIndices.Remove($ReferenceDictionaries[0])
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                foreach($ObjectIndex in @($ObjectIndices)) {
-                    $ObjectItem = $ObjectItems[$ObjectIndex]
-                    foreach ($ReferenceIndex in $ReferenceIndices) {
-                        $ReferenceItem = $ReferenceItems[$ReferenceIndex]
-                        if (CompareObject -Reference $ReferenceItem -Object $ObjectItem -IsEqual) {
-                            if ($MatchOrder -and $ObjectItem.Name -ne $ReferenceItem.Name) {
-                                if ($IsEqual) { return $false }
-                                [PSCustomObject]@{
-                                    Path        = $ReferenceNode.PathName
-                                    Discrepancy = 'Index'
-                                    InputObject = $ObjectItem.Name
-                                    Reference   = $ReferenceItem.Name
-                                }
-                            }
-                            $null = $ObjectIndices.Remove($ObjectIndex)
-                            $Null = $ReferenceIndices.Remove($ReferenceIndex)
-                            break # Only match a single node
-                        }
-                    }
-                }
-                for ($i = 0; $i -lt [math]::max($ObjectIndices.Count, $ReferenceIndices.Count); $i++) {
-                    $ObjectIndex    = if ($i -lt $ObjectIndices.Count)    { $ObjectIndices[$i] }
-                    $ReferenceIndex = if ($i -lt $ReferenceIndices.Count) { $ReferenceIndices[$i] }
-                    $ObjectItem     = if ($Null -ne $ObjectIndex)    { $ObjectItems[$ObjectIndex] }
-                    $ReferenceItem  = if ($Null -ne $ReferenceIndex) { $ReferenceItems[$ReferenceIndex] }
-                    if ($Null -eq $ObjectItem) {            # if ($IsEqual) { never happens as the size already differs
-                        [PSCustomObject]@{
-                            Path        = $ReferenceNode.PathName + "[$ReferenceIndex]"
-                            Discrepancy = 'Value'
-                            InputObject = $Null
-                            Reference   = if ($ReferenceItem -eq 'Scalar') { $ReferenceItem.Value } else { "[$($ReferenceItem.ValueType)]" }
-                        }
-                    }
-                    elseif ($Null -eq $ReferenceItem) {     # if ($IsEqual) { never happens as the size already differs
-                        [PSCustomObject]@{
-                            Path        = $ObjectNode.PathName + "[$ObjectIndex]"
-                            Discrepancy = 'Value'
-                            InputObject = if ($ObjectItem -eq 'Scalar') { $ObjectItem.Value } else { "[$($ObjectItem.ValueType)]" }
-                            Reference   = $Null
-                        }
-                    }
-                    else {
-                        $Compare = CompareObject -Reference $ReferenceItem -Object $ObjectItem
-                        if ($Compare -eq $false) { return $Compare } elseif ($Compare -ne $true) { $Compare }
-                    }
-                }
-            }
-            elseif ($ObjectNode -is [PSMapNode] -and $ReferenceNode -is [PSMapNode]) {
-                $Found = [HashTable]::new() # (Case sensitive)
-                $Order = if ($MatchOrder -and $ReferenceNode.ValueType.Name -ne 'HashTable') { [HashTable]::new() }
-                $Index = 0
-                if ($Order) { $ReferenceNode.Names.foreach{ $Order[$_] = $Index++ } }
-                $Index = 0
-                foreach ($ObjectItem in $ObjectNode.ChildNodes) {
-                    if ($ReferenceNode.Contains($ObjectItem.Name)) {
-                        $ReferenceItem = $ReferenceNode.GetChildNode($ObjectItem.Name)
-                        $Found[$ReferenceItem.Name] = $true
-                        if ($Order -and $Order[$ReferenceItem.Name] -ne $Index) {
-                            if ($IsEqual) { return $false }
-                            [PSCustomObject]@{
-                                Path        = $ObjectItem.PathName
-                                Discrepancy = 'Index'
-                                InputObject = $Index
-                                Reference   = $Order[$ReferenceItem.Name]
-                            }
-                        }
-                        $Compare = CompareObject -Reference $ReferenceItem -Object $ObjectItem
-                        if ($Compare -eq $false) { return $Compare } elseif ($Compare -ne $true) { $Compare }
-                    }
-                    else {
-                        if ($IsEqual) { return $false }
-                        [PSCustomObject]@{
-                            Path        = $ObjectItem.PathName
-                            Discrepancy = 'Exists'
-                            InputObject = $true
-                            Reference   = $false
-                        }
-                    }
-                    $Index++
-                }
-                $ReferenceNode.Names.foreach{
-                    if (-not $Found.Contains($_)) {
-                        if ($IsEqual) { return $false }
-                        [PSCustomObject]@{
-                            Path        = $ReferenceNode.GetChildNode($_).PathName
-                            Discrepancy = 'Exists'
-                            InputObject = $false
-                            Reference   = $true
-                        }
-                    }
-                }
-            }
-            else {
-                if ($IsEqual) { return $false }
-                [PSCustomObject]@{
-                    Path        = $ObjectNode.PathName
-                    Discrepancy = 'Structure'
-                    InputObject = $ObjectNode.ValueType.Name
-                    Reference   = $ReferenceNode.ValueType.Name
-                }
-            }            if ($IsEqual) { return $true }
         }
-        $ReferenceNode = [PSNode]::ParseInput($Reference, $MaxDepth)
+
+        $ObjectComparer = [ObjectComparer]@{ PrimaryKey = $PrimaryKey; ObjectComparison = $ObjectComparison }
+        $Node1 = [PSNode]::ParseInput($Reference, $MaxDepth)
     }
     process {
-        $ObjectNode = [PSNode]::ParseInput($InputObject, $MaxDepth)
-        $Arguments = @{
-            ReferenceNode = $ReferenceNode
-            ObjectNode    = $ObjectNode
-            PrimaryKey    = $PrimaryKey
-            IsEqual       = $IsEqual
-            MatchCase     = $MatchCase
-            MatchType     = $MatchType
-            MatchOrder    = $MatchOrder
-        }
-        CompareObject @Arguments
+        $Node2 = [PSNode]::ParseInput($InputObject, $MaxDepth)
+        if ($IsEqual) { $ObjectComparer.IsEqual($Node1, $Node2) }
+        else { $ObjectComparer.Report($Node1, $Node2) }
     }
 }

--- a/Source/Public/ConvertTo-Expression.ps1
+++ b/Source/Public/ConvertTo-Expression.ps1
@@ -7,14 +7,17 @@
     The object can be stored in a variable, (.psd1) file or any other common storage for later use or to be ported
     to another system.
 
-    expressions might be restored to an object using the native Invoke-Expression cmdlet:
+    expressions might be restored to an object using the native [Invoke-Expression] cmdlet:
 
         $Object = Invoke-Expression ($Object | ConvertTo-Expression)
 
-    Or using the [PSNode Object Parser][1] (*under construction*).
+    > [!Warning]
+    > Take reasonable precautions when using the Invoke-Expression cmdlet in scripts. When using `Invoke-Expression`
+    > to run a command that the user enters, verify that the command is safe to run before running it.
+    > In general, it is best to restore your objects using [ConvertFrom-Expression].
 
     > [!Note]
-    > Some object types can not be constructed from a a simple serialized expression
+    > Some object types can not be reconstructed from a simple serialized expression.
 
 .INPUTS
     Any. Each objects provided through the pipeline will converted to an expression. To concatenate all piped
@@ -141,6 +144,7 @@ function ConvertTo-Expression {
             if ($Explicit)     { StopError 'The Explicit switch requires Constrained - or FullLanguage mode.' }
             if ($FullTypeName) { StopError 'The FullTypeName switch requires Constrained - or FullLanguage mode.' }
         }
+
     }
 
     process {

--- a/Source/Public/Copy-ObjectGraph.ps1
+++ b/Source/Public/Copy-ObjectGraph.ps1
@@ -62,29 +62,8 @@ function Copy-ObjectGraph {
             $PSCmdlet.ThrowTerminatingError([System.Management.Automation.ErrorRecord]::new($Exception, $Id, $Group, $Object))
         }
 
-        function NewNode($Object) {
-            if ($Null -eq $Object) { return }
-            elseif ($Object -is [String]) {
-                $TypeName = Switch ($Object) {
-                    'ordered'                                     { 'System.Collections.Specialized.OrderedDictionary' }
-                    'System.Management.Automation.PSCustomObject' { 'PSCustomObject' }
-                    Default                                       { $Object }
-                }
-                $Type = $TypeName -as [Type]
-                if (-not $Type) { StopError "Unknown type: [$Object]" }
-                if ('System.Object[]', 'System.Array' -eq $Type.FullName) { $Object = @() }
-                else { $Object = New-Object -Type $TypeName }
-            }
-            elseif ($Type -is [Type]) {
-                if ('System.Object[]', 'System.Array' -eq $Type) { $Object = @() }
-                elseif ('System.Management.Automation.PSCustomObject' -eq $Type) { $Object = [PSCustomObject]@{} }
-                else { $Object = New-Object -Type $Type.FullName }
-            }
-            [PSNode]::ParseInput($Object)
-        }
-
-        $ListNode = NewNode $ListAs
-        $MapNode  = NewNode $MapAs
+        $ListNode = if ($PSBoundParameters.ContainsKey('ListAs')) { [PSNode]::ParseInput([PSInstance]::Create($ListAs)) }
+        $MapNode  = if ($PSBoundParameters.ContainsKey('MapAs'))  { [PSNode]::ParseInput([PSInstance]::Create($MapAs)) }
 
         if (
             $ListNode -is [PSMapNode] -and $MapNode -is [PSListNode] -or

--- a/Source/Public/Import-ObjectGraph.ps1
+++ b/Source/Public/Import-ObjectGraph.ps1
@@ -37,15 +37,15 @@
     > best to design your configuration expressions with restricted or constrained classes, rather than
     > allowing full freeform expressions.
 
-.PARAMETER ArrayAs
+.PARAMETER ListAs
     If supplied, the array subexpression `@( )` syntaxes without an type initializer or with an unknown or
     denied type initializer will be converted to the given list type.
 
-.PARAMETER HashTableAs
+.PARAMETER MapAs
     If supplied, the array subexpression `@{ }` syntaxes without an type initializer or with an unknown or
     denied type initializer will be converted to the given map (dictionary or object) type.
 
-    The default `HashTableAs` is an (ordered) `PSCustomObject` for PowerShell Data (`psd1`) files and
+    The default `MapAs` is an (ordered) `PSCustomObject` for PowerShell Data (`psd1`) files and
     a (unordered) `HashTable` for any other files, which usually concerns PowerShell (`.ps1`) files that
     support explicit type initiators.
 
@@ -69,9 +69,9 @@ function Import-ObjectGraph {
         [string[]]
         $LiteralPath,
 
-        [ValidateNotNull()]$ArrayAs,
+        [ValidateNotNull()]$ListAs,
 
-        [ValidateNotNull()]$HashTableAs,
+        [ValidateNotNull()]$MapAs,
 
         [ValidateScript({ $_ -ne 'NoLanguage' })]
         [System.Management.Automation.PSLanguageMode]$LanguageMode,
@@ -84,11 +84,11 @@ function Import-ObjectGraph {
         if (-not $PSBoundParameters.ContainsKey('LanguageMode')) {
             $PSBoundParameters['LanguageMode'] = if ($Extension -eq '.psd1') { 'Restricted' } else { 'Constrained' }
         }
-        if (-not $PSBoundParameters.ContainsKey('HashTableAs') -and $Extension -eq '.psd1') {
-            $PSBoundParameters['HashTableAs'] = 'PSCustomObject'
+        if (-not $PSBoundParameters.ContainsKey('MapAs') -and $Extension -eq '.psd1') {
+            $PSBoundParameters['MapAs'] = 'PSCustomObject'
         }
 
-        $FromExpressionParameters = 'ArrayAs', 'HashTableAs', 'LanguageMode'
+        $FromExpressionParameters = 'ListAs', 'MapAs', 'LanguageMode'
         $FromExpressionArguments = @{}
         $FromExpressionParameters.where{ $PSBoundParameters.ContainsKey($_) }.foreach{ $FromExpressionArguments[$_] = $PSBoundParameters[$_] }
         $FromExpressionContext = $ExecutionContext.InvokeCommand.GetCommand('ObjectGraphTools\ConvertFrom-Expression', [System.Management.Automation.CommandTypes]::Cmdlet)

--- a/Source/Public/New-Schema.ps1
+++ b/Source/Public/New-Schema.ps1
@@ -1,0 +1,27 @@
+function New-Schema {
+    [CmdletBinding(HelpUri='https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/New-Schema.md')][OutputType([String])] param(
+
+        [Parameter(Mandatory = $true, ValueFromPipeLine = $True)]
+        $InputObject
+    )
+
+    begin {
+        function GetSchema([PSNode]$Node, $Parent) {
+            # if ($PSVersionTable.PSVersion.Major -eq 5) {
+            #     try { [void][Newtonsoft.Json.JsonConverter] }
+            #     catch { Add-Type -Path "$PSScriptRoot/Assembly/Newtonsoft.Json.dll" }
+            # }
+        }
+    }
+
+    process {
+        # $Schema = @{}
+        # $Node = [PSNode]::parse($InputObject)
+        # GetSchema $Node
+        [Newtonsoft.Json.Schema]::Create()
+        [Newtonsoft.Json.Schema.JsonSchema]::JsonSchema()
+        [Microsoft.AnalysisServices.Tabular]::new()
+    }
+
+}
+

--- a/Source/Public/Test-ObjectGraph copy.ps1
+++ b/Source/Public/Test-ObjectGraph copy.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Tests the properties of an object-graph.
+
+.DESCRIPTION
+    Tests an object-graph against a schema object by verifying that the properties of the object-graph
+    meet the constrains defined in the schema object.
+#>
+
+Enum NodeType { Leaf; List; Map }
+
+# JsonSchema Properties
+# Schema properties: [Newtonsoft.Json.Schema.JsonSchema]::New() | Get-Member
+# https://www.newtonsoft.com/json/help/html/Properties_T_Newtonsoft_Json_Schema_JsonSchema.htm
+Enum PSSchemaName {
+    Title
+    Node
+    Type
+    Items
+}
+function New-Schema {
+    [CmdletBinding(HelpUri='https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/Test-ObjectGraph.md')][OutputType([String])] param(
+
+        [Parameter(Mandatory = $true, ValueFromPipeLine = $True)]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        $SchemaObject,
+
+        [Alias('Depth')][int]$MaxDepth = [PSNode]::DefaultMaxDepth
+    )
+
+
+
+    begin {
+
+
+        $NodeTypeCache = [System.Collections.Generic.Dictionary[String,NodeType]]::new()
+
+        $NodeNames = {
+            PSLeafNode       = 'Leaf'
+            PSListNode       = 'List'
+            PSDictionaryNode = 'Map'
+            PSObjectNode     = 'Map'
+        }
+        function TestObject([PSNode]$ObjectNode, [PSNode]$SchemaNode) {
+            $Verbose = $VerbosePreference -in 'Stop', 'Continue', 'Inquire'
+            if ($Verbose) { Write-Verbose $ObjectNode.Path }
+            $ObjectNodeType = $NodeNames["$ObjectNode"]
+            $SchemaNodeType = $Null
+            foreach ($PSSchemaName in [PSSchemaName].GetEnumValues()) {
+                if (-not $DefinitionNode.GetChildNode("$PSSchemaName")) { continue }
+                $DefinitionNode = $SchemaNode.GetChildNode("$PSSchemaName")
+                $Test = Switch ($PSSchemaName) {
+                    Title {
+                        Write-Verbose "    $($DefinitionNode.Value)"
+                    }
+                    Node { # Should be tested before the type
+                        $SchemaNodeType = [NodeType]$DefinitionNode.Value
+                        if ($ObjectNodeType -ne $SchemaNodeType) {
+                            "Expected $($ObjectNode.Path) to be a SchemaNodeType node, but got $($ObjectNode.Value) which is a $ObjectNodeType node."
+                        }
+                    }
+                    Type {
+                        $Type = $DefinitionNode.Value -as [Type]
+                        if (-not $Type) {
+                            Throw "Schema error at $($SchemaNode.Path).Type: Unknown type [$($DefinitionNode.Value)] in schema definition"
+                        }
+                        if ($SchemaNodeType) {
+                                if (-Not $NodeTypeCache.ContainsKey($Type)) {
+                                $PSInstance = [PSInstance]::Create($Type)
+                                $NodeTypeCache[$Type] = $NodeNames["$PSInstance"]
+                            }
+                            if ($SchemaNodeType -ne $NodeTypeCache[$Type]) {
+                                Throw "Schema error at $($SchemaNode.Path).Type: $Type is not a $SchemaNodeType node"
+                            }
+                        }
+                        if ($ObjectNode.Value -isnot $Type) {
+                            "Expected $($ObjectNode.Path) to be a [$($DefinitionNode.Value)] type, but got $($ObjectNode.Value) of type [$($Object.GetType())]."
+                        }
+                    }
+                    Items {
+                        if ($ObjectNode -is [PSMapNode]) {
+                            if ($SchemaNode -is [PSMapNode]) {
+                                foreach ($ItemNode in $ConditionNode.ChildNodes) {
+                                    $ChildNode = $ObjectNode.GetChildNode($ItemNode.Name) # Items are not necessarily required
+                                    if ($ChildNode) { TestObject $ChildNode $PropertyNode }
+                                }
+                            }
+                            else {
+                                "Expected $($ObjectNode.Path) to be a list node, but got a map node."
+                            }
+                        }
+                        elseif ($ObjectNode -is [PSListNode]) {
+                            if ($SchemaNode -is [PSListNode]) {
+                                $Index = 0
+                                foreach ($ItemNode in $ConditionNode.ChildNodes) {
+                                    $ChildNode = $ObjectNode.GetChildNode($Index) # Items are not necessarily required
+                                    if ($ChildNode) { TestObject $ChildNode $PropertyNode }
+                                }
+                            }
+                            else {
+                                "Expected $($ObjectNode.Path) to be a map node, but got a list node."
+                            }
+                        }
+                        else {
+                            "Expected $($ObjectNode.Path) to contain items, but got a leaf node."
+                        }
+                    }
+                }
+                if ($Test) { Write-Host $Test }
+            }
+        }
+        $SchemaNode = [PSNode]::ParseInput($SchemaObject)
+    }
+
+    process {
+        $ObjectNode = [PSNode]::ParseInput($InputObject, $MaxDepth)
+        TestObject
+    }
+}

--- a/Source/Public/Test-ObjectGraph.ps1
+++ b/Source/Public/Test-ObjectGraph.ps1
@@ -1,0 +1,196 @@
+<#
+.SYNOPSIS
+    Tests the properties of an object-graph.
+
+.DESCRIPTION
+    Tests an object-graph against a schema object by verifying that the properties of the object-graph
+    meet the constrains defined in the schema object.
+#>
+
+# JsonSchema Properties
+# Schema properties: [Newtonsoft.Json.Schema.JsonSchema]::New() | Get-Member
+# https://www.newtonsoft.com/json/help/html/Properties_T_Newtonsoft_Json_Schema_JsonSchema.htm
+# Enum PSSchemaName {
+#     Title
+#     Type
+#     PrimaryKey # Should be red before items
+#     Items
+# }
+function Test-ObjectGraph {
+    [CmdletBinding(HelpUri='https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/Test-ObjectGraph.md')][OutputType([String])] param(
+
+        [Parameter(Mandatory = $true, ValueFromPipeLine = $True)]
+        $InputObject,
+
+        [Parameter(Mandatory = $true, Position = 0)]
+        $SchemaObject,
+
+        [Switch]$IsValid,
+
+        [Switch]$ShowAll,
+
+        [Alias('Depth')][int]$MaxDepth = [PSNode]::DefaultMaxDepth
+    )
+
+
+
+    begin {
+
+
+        #  $NodeTypeCache = [System.Collections.Generic.Dictionary[String,NodeType]]::new()
+
+        # $DefinitionOrder = @('Title', 'Type')
+
+        function TestObject([PSNode]$ObjectNode, [PSMapNode]$SchemaNode, [Switch]$IsValid) {
+            $Verbose = $VerbosePreference -in 'Stop', 'Continue', 'Inquire'
+            if ($Verbose) { Write-Verbose $ObjectNode.Path }
+            if (-not $IsValid) { $Violations = [Collections.Generic.List[Object]]::new() }
+            $DefinitionNodes = @{}
+            foreach ($ChildNode in $SchemaNode.ChildNodes) { $DefinitionNodes[$ChildNode.Name] = $ChildNode }
+            foreach ($Name in @('Title', 'Type', 'List', 'Required', 'Optional')) {
+                if (-not $DefinitionNodes.Contains($Name)) { continue }
+                $DefinitionNode = $DefinitionNodes[$Name]
+                $Definition = $DefinitionNode.Value
+                if ($Verbose) { Write-Verbose "    Testing: $Name = $Definition" }
+                $Expected, $Actual = $Null # Setting the $Actual will break the iteration
+                $Checked = [Collections.Generic.HashSet[int]]::new()
+                switch ($DefinitionNode.Name) {
+                    Type {
+                        $Type = $Definition -as [Type]
+                        if (-not $Type) {
+                            Throw "Schema error at $($SchemaNode.Path).Type: Unknown type [$Definition] in schema definition"
+                        }
+                        $Invalid = $ObjectNode.Value -isnot $Type
+                        if ($IsValid -and $Invalid) { return $false }
+                        if ($ShowAll -or $Invalid) { $Expected = "[$Definition] type" }
+                        if ($Invalid) { $Actual = "$($ObjectNode.Value) of type [$($ObjectNode.ValueType)]" }
+                    }
+                    { $_ -in 'List', 'Required', 'Optional' } {
+                        $Invalid = ($ObjectNode.NodeStructure -ne $DefinitionNode.NodeStructure)
+                        if ($IsValid -and $Invalid) { return $false }
+                        if ($ShowAll -or $Invalid) { $Expected = "$($DefinitionNode.NodeStructure) structure" }
+                        if ($Invalid) { $Actual = "$($ObjectNode.Value) with $($ObjectNode.NodeStructure) structure" }
+                    }
+                    List {
+                        if ($ObjectNode -isnot [PSCollectionNode]) { continue } # $ObjectNode and $DefinitionNode are already tested equal structures
+                        if ($Definition -is [HashTable]) {
+                            Throw "Schema error at $($SchemaNode.Path).List: Testing a map list requires an ordered dictionary or PSCustomObject."
+                        }
+                        if ($ObjectNode.Value -is [HashTable]) {
+                            $Expected = "an ordered dictionary or PSCustomObject"
+                            $Actual = "'$($ObjectNode.Type)'"
+                            break
+                        }
+                        $Index = 0
+                        $DefinitionNodes = $DefinitionNode.ChildNodes
+                        foreach ($ChildNode in $ObjectNode.ChildNodes) {
+                            $DefinitionNode = $DefinitionNodes[$Index++]
+                            $Invalid = $ObjectNode -is [PSMapNode] -and $ObjectNode.Name -ne $DefinitionNode.Name
+                            if ($IsValid -and $Invalid) { return $false }
+                            if ($ShowAll -or $Invalid) { $Expected = "node #$Index named '$($DefinitionNode.Name)'" }
+                            if ($Invalid) { $Actual = "'$($ObjectNode.Name)'" }
+                            else {
+                                $TestObject = TestObject $ChildNode $DefinitionNode $IsValid
+                                if ($null -ne $TestObject) { $null = $Checked.add($Index) }
+                                else { if ($IsValid) { Return $false } else { $Violations.AddRange($TestObject) } }
+                            }
+                        }
+                    }
+                    Required {
+                        if ($ObjectNode -is [PSListNode]) { # $ObjectNode and $DefinitionNode are already tested equal structures
+                            foreach ($RequiredNode in $DefinitionNode.ChildNodes) {
+                                $Index = 0
+                                $TestObject = $null
+                                foreach ($ChildNode in $ObjectNode.ChildNodes) {
+                                    if ($ChildNode -notin $Checked) {
+                                        $TestObject = TestObject $ChildNode $RequiredNode -IsValid
+                                        if ($TestObject) { $null = $Checked.add($Index) }
+                                    }
+                                    $Index++
+                                }
+                                $Invalid = $null -eq $TestObject
+                                if ($IsValid -and $Invalid) { return $false }
+                                if ($ShowAll -or $Invalid) { $Expected = $($RequiredNode.Value) }
+                                if ($Invalid) { $Actual = "$($RequiredNode.Name) = $($RequiredNode.Value) doesn't exist" }
+                            }
+                        }
+                        elseif ($ObjectNode -is [PSMapNode]) {
+                            $Index = 0
+                            foreach ($RequiredNode in $DefinitionNode.ChildNodes) {
+                                $KeyExists = $ObjectNode.Contains($RequiredNode.Name)
+                                if ($KeyExists) {
+                                    $null = $Checked.add($Index)
+                                    $ChildNode = $ObjectNode.GetChildNode($RequiredNode.Name)
+                                    $TestObject = TestObject $ChildNode $RequiredNode $IsValid
+                                    if ($null -ne $TestObject) { if ($IsValid) { Return $false } else { $Violations.AddRange(@($TestObject)) } }
+                                }
+                                $Invalid = -Not $KeyExists
+                                if ($IsValid -and $Invalid) { return $false }
+                                if ($ShowAll -or $Invalid) { $Expected = "containing '$($RequiredNode.Name)'" }
+                                if ($Invalid) { $Actual = "'$($RequiredNode.Name)' doesn't exist" }
+                                $Index++
+                            }
+                        }
+                    }
+                    Optional {
+                        if ($ObjectNode -is [PSListNode]) { # $ObjectNode and $DefinitionNode are already tested equal structures
+                            foreach ($OptionalNode in $DefinitionNode.ChildNodes) {
+                                $Index = 0
+                                foreach ($ChildNode in $ObjectNode.ChildNodes) {
+                                    if ($ChildNode -notin $Checked) {
+                                        $TestObject = TestObject $ChildNode $OptionalNode -IsValid
+                                        if ($TestObject) { $Checked.add($Index) }
+                                    }
+                                    $Index++
+                                }
+                            }
+                        }
+                        elseif ($ObjectNode -is [PSMapNode]) {
+                            $Index = 0
+                            foreach ($OptionalNode in $DefinitionNode.ChildNodes) {
+                                if ($ObjectNode.Contains($OptionalNode.Name)) {
+                                    $null = $Checked.add($Index)
+                                    $ChildNode = $ObjectNode.GetChildNode($RequiredNode.Name)
+                                    $TestObject = TestObject $ChildNode $OptionalNode $IsValid
+                                    if ($null -ne $TestObject) { if ($IsValid) { Return $false } else { $Violations.AddRange(@($TestObject)) } }
+                                }
+                                $Index++
+                            }
+                        }
+                        $Invalid = $Checked.Count -lt $ObjectNode.Count
+                        if ($IsValid -and $Invalid) { return $false }
+                        if ($ShowAll -or $Invalid) { $Expected = "optional node" }
+                        if ($Invalid) {
+                            $Index = 0
+                            $RedundantNames = foreach ($Node in $ObjectNode.ChildNodes) {
+                                if ($Index++ -in $Checked) { continue }
+                                $Node.Name
+                            } -Join ', '
+                            $Actual = "the following nodes are not optional: $RedundantNames"
+                        }
+                    }
+                }
+                if ($Expected) {
+                    Write-Host 123
+                    $Violations.Add(
+                        [PSCustomObject]@{
+                            Path     = $ObjectNode.Path
+                            Value    = "$($ObjectNode.Value)"
+                            Expected = $Expected
+                            Actual   = $Actual
+                        }
+                    )
+                    return $Violations
+                }
+            }
+            if ($Violations) { $Violations }
+        }
+
+        $SchemaNode = [PSNode]::ParseInput($SchemaObject)
+    }
+
+    process {
+        $ObjectNode = [PSNode]::ParseInput($InputObject, $MaxDepth)
+        TestObject $ObjectNode $SchemaNode $IsValid
+    }
+}

--- a/Tests/Compare-ObjectGraph.Tests.ps1
+++ b/Tests/Compare-ObjectGraph.Tests.ps1
@@ -122,7 +122,7 @@ Describe 'Compare-ObjectGraph' {
         $Result[0].InputObject | Should -Be 2
         $Result[0].Reference   | Should -Be 3
         $Result[1].Path        | Should -Be 'Data[2]'
-        $Result[1].Discrepancy | Should -Be 'Value'
+        $Result[1].Discrepancy | Should -Be 'Exists'
         $Result[1].InputObject | Should -BeNullOrEmpty
         $Result[1].Reference   | Should -Be '[HashTable]'
     }
@@ -160,7 +160,7 @@ Describe 'Compare-ObjectGraph' {
         $Result[0].InputObject | Should -Be 4
         $Result[0].Reference   | Should -Be 3
         $Result[1].Path        | Should -Be 'Data[3]'
-        $Result[1].Discrepancy | Should -Be 'Value'
+        $Result[1].Discrepancy | Should -Be 'Exists'
         $Result[1].InputObject | Should -Be '[HashTable]'
         $Result[1].Reference   | Should -Be $Null
     }
@@ -214,11 +214,11 @@ Describe 'Compare-ObjectGraph' {
                 }
             )
         }
-        $Object | Compare-ObjectGraph $Reference -IsEqual | Should -Be $True
-        $Object | Compare-ObjectGraph $Reference -MatchOrder -IsEqual | Should -Be $False
-        $Object | Compare-ObjectGraph $Reference -PrimaryKey Index -MatchOrder -IsEqual | Should -Be $True
-        $Result = $Object | Compare-ObjectGraph $Reference -MatchOrder
-        $Result.Count     | Should -Be 2
+        $Object | Compare-ObjectGraph $Reference -IsEqual | Should -Be $False
+        $Object | Compare-ObjectGraph $Reference -IgnoreListOrder -IsEqual | Should -Be $True
+        $Object | Compare-ObjectGraph $Reference -PrimaryKey Index -IsEqual | Should -Be $True
+        $Result = $Object | Compare-ObjectGraph $Reference
+        $Result.Count | Should -Be 6
     }
     It 'Unordered (hashtable) reference' {
         $Object = @{
@@ -329,9 +329,9 @@ Describe 'Compare-ObjectGraph' {
             )
         }
         $Object | Compare-ObjectGraph $Ordered -IsEqual | Should -Be $True
-        $Object | Compare-ObjectGraph $Ordered -MatchOrder -IsEqual | Should -Be $False
-        $Object | Compare-ObjectGraph $Ordered -PrimaryKey Index -MatchOrder -IsEqual | Should -Be $False
-        $Result = $Object | Compare-ObjectGraph $Ordered -MatchOrder
+        $Object | Compare-ObjectGraph $Ordered -MatchMapOrder -IsEqual | Should -Be $False
+        $Object | Compare-ObjectGraph $Ordered -PrimaryKey Index -MatchMapOrder -IsEqual | Should -Be $False
+        $Result = $Object | Compare-ObjectGraph $Ordered -MatchMapOrder
         $Result.Count     | Should -Be 2
     }
 

--- a/Tests/ConvertFrom-Expression.Test.ps1
+++ b/Tests/ConvertFrom-Expression.Test.ps1
@@ -6,9 +6,6 @@ using module ..\..\ObjectGraphTools
 [Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Expression', Justification = 'False positive')]
 param()
 
-# $PesterPreference = [PesterConfiguration]::Default
-# $PesterPreference.Should.ErrorAction = 'Stop'
-
 Describe 'ConvertFrom-Expression' {
 
     BeforeAll {
@@ -79,6 +76,14 @@ Describe 'ConvertFrom-Expression' {
     spouse = $Null
 }
 '@
+        }
+    }
+
+    Context 'Issues' {
+
+        It '#90 Add $PSCulture and $PSUICulture to the restricted language mode cmdlets and classes' {
+            '@{ Culture = $PSCulture }'   | ConvertFrom-Expression | ConvertTo-Expression | Should -be "@{ Culture = '$PSCulture' }"
+            '@{ Culture = $PSUICulture }' | ConvertFrom-Expression | ConvertTo-Expression | Should -be "@{ Culture = '$PSUICulture' }"
         }
     }
 }

--- a/Tests/ConvertTo-Expression.Tests.ps1
+++ b/Tests/ConvertTo-Expression.Tests.ps1
@@ -625,7 +625,7 @@ Describe 'ConvertTo-Expression' {
         }
 
         It 'ConvertTo-Expression (Default)' {
-            $Expression = ConvertTo-Expression -InputObject $Object
+            $Expression = ConvertTo-Expression -InputObject $Object 
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
 @{
@@ -778,14 +778,14 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{number='212 555-1234' }, @{number='646 555-4567' });children=@('Catherine');spouse=$Null }
+@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandSingleton -ExpandDepth -1' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandSingleton -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234' }, @{ number='646 555-4567' });children=@('Catherine');spouse=$Null }
+@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Constrained' {
@@ -1092,28 +1092,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{number='212 555-1234' }, @{number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[PSCustomObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{number='212 555-1234' }, @{number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234' }, @{ number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[PSCustomObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234' }, @{ number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Constrained -Explicit' {
@@ -1420,28 +1420,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234' }, [hashtable]@{number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234' }, [hashtable]@{ number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Full' {
@@ -1748,28 +1748,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234' }, [hashtable]@{number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234' }, [hashtable]@{ number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Full -Explicit' {
@@ -2076,28 +2076,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234' }, [hashtable]@{number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Full -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Full -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234' }, [hashtable]@{ number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
     }
@@ -2106,6 +2106,23 @@ Describe 'ConvertTo-Expression' {
 
         It '#59 quoting bug' {
             @{ Test = "foo'bar" } | ConvertTo-Expression | Should -Be "@{ Test = 'foo''bar' }"
+        }
+
+        It '#87 ConvertTo-Expression: keys with special characters should be quoted' { # https://stackoverflow.com/questions/62754771/unquoted-key-rules-and-best-practices
+            @{ a = 1 }     | ConvertTo-Expression | Should -Be '@{ a = 1 }'
+            @{ '$a'  = 1 } | ConvertTo-Expression | Should -Be '@{ ''$a'' = 1 }' # --> @{ '$a' = 1 }
+            @{ 'a b' = 1 } | ConvertTo-Expression | Should -Be "@{ 'a b' = 1 }"
+            @{ 'a"b' = 1 } | ConvertTo-Expression | Should -Be "@{ 'a""b' = 1 }" # --> @{ 'a"b' = 1 }
+            @{ "a'b" = 1 } | ConvertTo-Expression | Should -Be "@{ 'a''b' = 1 }"
+        }
+
+        It '#92 ConvertTo-Expression -Expand -1 leaves space after map value' {
+            @{ a = 1 } | ConvertTo-Expression -ExpandDepth -1 | Should -Be '@{a=1}'
+        }
+
+        It '#91 ConvertTo-Expression: better handle special type keys' {
+            @{ (Get-Date 1963-10-07) = 7 } | ConvertTo-Expression      | Should -Be "@{ '1963-10-07T00:00:00.0000000' = 7 }"
+            @{ @{ a = 1 } = 'Test' } | ConvertTo-Expression -Expand -1 | Should -Be "@{@{a=1}='Test'}"
         }
     }
 }

--- a/Tests/Get-Node.Tests.ps1
+++ b/Tests/Get-Node.Tests.ps1
@@ -2,8 +2,9 @@
 
 using module ..\..\ObjectGraphTools
 
-[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Object', Justification = 'False positive')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Object',      Justification = 'False positive')]
 [Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'ObjectGraph', Justification = 'False positive')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Nodes',       Justification = 'False positive')]
 param()
 
 Describe 'Get-Node' {
@@ -135,6 +136,21 @@ Describe 'Get-Node' {
             $Title.Value | Should -Be 'Learning PowerShell'
         }
 
+    }
+
+    Context 'Unique' {
+
+        BeforeAll {
+            $Nodes = ($Object | Get-Node 'data.name=*o*') + ($Object | Get-Node 'data.name=*t*')
+        }
+
+        it 'Concatenated nodes' {
+            ($Nodes | Get-Node).Count | Should -be 4
+        }
+
+        it 'Merged nodes' {
+            ($Nodes | Get-Node -Unique).Count | Should -be 3
+        }
     }
 
     Context 'Change value' {

--- a/Tests/Import-ObjectGraph.Tests.ps1
+++ b/Tests/Import-ObjectGraph.Tests.ps1
@@ -64,7 +64,7 @@ Describe 'Import-ObjectGraph' {
         }
 
         It "AsHashTable" {
-            $Object = Import-ObjectGraph $PSD1File -HashTableAs @{}
+            $Object = Import-ObjectGraph $PSD1File -MapAs @{}
             $Object            | Should -BeOfType HashTable
             $Object.Keys       | Sort-Object | Should -Be 'address', 'age', 'birthday', 'children', 'first_name', 'is_alive', 'last_name', 'phone_numbers', 'spouse'
             $Object.Address    | Should -not -BeNullOrEmpty  # Cash insensitive

--- a/Tests/PSInstance.Tests.ps1
+++ b/Tests/PSInstance.Tests.ps1
@@ -1,0 +1,237 @@
+#Requires -Modules @{ModuleName="Pester"; ModuleVersion="5.5.0"}
+
+using module ..\..\ObjectGraphTools
+
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Object', Justification = 'False positive')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Node',   Justification = 'False positive')]
+param()
+
+Describe 'PSInstance' {
+
+    BeforeAll {
+        Set-StrictMode -Version Latest
+    }
+
+    Context 'Existence Check' {
+
+        It 'Loaded' {
+            [PSInstance]::new() -is [PSInstance] | Should -BeTrue
+        }
+    }
+
+    Context 'By string' {
+
+        it 'String' {
+            [PSInstance]::Create('String')        | Should -BeOfType String
+            [PSInstance]::Create('[String]')      | Should -BeOfType String
+            [PSInstance]::Create('System.String') | Should -BeOfType String
+        }
+
+        it 'Int' {
+            [PSInstance]::Create('Int')          | Should -BeOfType Int
+            [PSInstance]::Create('Int32')        | Should -BeOfType Int
+            [PSInstance]::Create('[Int]')        | Should -BeOfType Int
+            [PSInstance]::Create('System.Int32') | Should -BeOfType Int
+        }
+
+        it 'Char' {
+            [PSInstance]::Create('Char') | Should -BeOfType Char
+        }
+
+        it 'DateTime' {
+            [PSInstance]::Create('DateTime') | Should -BeOfType DateTime
+        }
+
+        it 'ScriptBlock' {
+            [PSInstance]::Create('ScriptBlock') | Should -BeOfType ScriptBlock
+        }
+
+        it 'Array' {
+            [PSInstance]::Create('Array')           | Should -BeOfType Array
+            [PSInstance]::Create('Object[]')        | Should -BeOfType Array
+            [PSInstance]::Create('System.Object[]') | Should -BeOfType Array
+        }
+
+        it 'HashTable' {
+            [PSInstance]::Create('HashTable')                    | Should -BeOfType HashTable
+            [PSInstance]::Create('Collections.hashtable')        | Should -BeOfType HashTable
+            [PSInstance]::Create('System.Collections.Hashtable') | Should -BeOfType HashTable
+        }
+
+        it 'List[Object]' {
+            ,[PSInstance]::Create('Collections.Generic.List[Object]')               | Should -BeOfType Collections.Generic.List[Object]
+            ,[PSInstance]::Create('System.Collections.Generic.List[Object]')        | Should -BeOfType Collections.Generic.List[Object]
+            ,[PSInstance]::Create('Collections.Generic.List[System.Object]')        | Should -BeOfType Collections.Generic.List[Object]
+            ,[PSInstance]::Create('System.Collections.Generic.List[System.Object]') | Should -BeOfType Collections.Generic.List[Object]
+        }
+
+        it 'List[String]' {
+            ,[PSInstance]::Create('Collections.Generic.List[String]')               | Should -BeOfType Collections.Generic.List[String]
+            ,[PSInstance]::Create('System.Collections.Generic.List[String]')        | Should -BeOfType Collections.Generic.List[String]
+            ,[PSInstance]::Create('Collections.Generic.List[System.String]')        | Should -BeOfType Collections.Generic.List[String]
+            ,[PSInstance]::Create('System.Collections.Generic.List[System.String]') | Should -BeOfType Collections.Generic.List[String]
+        }
+
+        it 'Dictionary[String,String]' {
+            [PSInstance]::Create('Collections.Generic.Dictionary[String,String]')        | Should -BeOfType 'Collections.Generic.Dictionary[String,String]'
+            [PSInstance]::Create('System.Collections.Generic.Dictionary[String,String]') | Should -BeOfType 'Collections.Generic.Dictionary[String,String]'
+        }
+
+        it 'Dictionary[String,Object]' {
+            [PSInstance]::Create('Collections.Generic.Dictionary[String,Object]')        | Should -BeOfType 'Collections.Generic.Dictionary[String,Object]'
+            [PSInstance]::Create('System.Collections.Generic.Dictionary[String,Object]') | Should -BeOfType 'Collections.Generic.Dictionary[String,Object]'
+        }
+
+        it 'Ordered' {
+            [PSInstance]::Create('Ordered')                                          | Should -BeOfType Collections.Specialized.OrderedDictionary
+            [PSInstance]::Create('Collections.Specialized.OrderedDictionary')        | Should -BeOfType Collections.Specialized.OrderedDictionary
+            [PSInstance]::Create('System.Collections.Specialized.OrderedDictionary') | Should -BeOfType Collections.Specialized.OrderedDictionary
+        }
+
+        it 'PSCustomObject' {
+            [PSInstance]::Create('PSObject')                                    | Should -BeOfType Management.Automation.PSCustomObject
+            [PSInstance]::Create('Management.Automation.PSObject')              | Should -BeOfType Management.Automation.PSCustomObject
+            [PSInstance]::Create('System.Management.Automation.PSObject')       | Should -BeOfType Management.Automation.PSCustomObject
+            [PSInstance]::Create('PSCustomObject')                              | Should -BeOfType Management.Automation.PSCustomObject
+            [PSInstance]::Create('Management.Automation.PSCustomObject')        | Should -BeOfType Management.Automation.PSCustomObject
+            [PSInstance]::Create('System.Management.Automation.PSCustomObject') | Should -BeOfType Management.Automation.PSCustomObject
+        }
+    }
+    Context 'By type' {
+
+        it 'String' {
+            [PSInstance]::Create([String]) | Should -BeOfType String
+        }
+
+        it 'Int' {
+            [PSInstance]::Create([Int]) | Should -BeOfType Int
+        }
+
+        it 'Char' {
+            [PSInstance]::Create([Char]) | Should -BeOfType Char
+        }
+
+        it 'DateTime' {
+            [PSInstance]::Create([DateTime]) | Should -BeOfType DateTime
+        }
+
+        it 'ScriptBlock' {
+            [PSInstance]::Create([ScriptBlock]) | Should -BeOfType ScriptBlock
+        }
+
+        it 'HashTable' {
+            [PSInstance]::Create([HashTable]) | Should -BeOfType HashTable
+        }
+
+        it 'List[Object]' {
+            ,[PSInstance]::Create([Collections.Generic.List[Object]]) | Should -BeOfType Collections.Generic.List[Object]
+        }
+
+        it 'List[String]' {
+            ,[PSInstance]::Create([Collections.Generic.List[String]]) | Should -BeOfType Collections.Generic.List[String]
+        }
+
+        it 'Dictionary[String,String]' {
+            [PSInstance]::Create([Collections.Generic.Dictionary[String,String]]) | Should -BeOfType 'Collections.Generic.Dictionary[String,String]'
+        }
+
+        it 'Dictionary[String,Object]' {
+            [PSInstance]::Create([Collections.Generic.Dictionary[String,Object]]) | Should -BeOfType 'Collections.Generic.Dictionary[String,Object]'
+        }
+
+        it 'Ordered' {
+            [PSInstance]::Create([Collections.Specialized.OrderedDictionary]) | Should -BeOfType Collections.Specialized.OrderedDictionary
+        }
+
+        it 'PSCustomObject' {
+            [PSInstance]::Create([PSCustomObject]) | Should -BeOfType Management.Automation.PSCustomObject
+        }
+    }
+
+    Context 'By example' {
+
+        it 'String' {
+            # As [PSInstance]::Create() support a TypeName (string) as input
+            # Only an empty string might be used as an sample value
+            # The rest will either assumed to be a TypeName or fail.
+            [PSInstance]::Create('')              | Should -BeOfType String
+        }
+
+        it 'Int' {
+            [PSInstance]::Create(0)  | Should -BeOfType Int
+            [PSInstance]::Create(42) | Should -BeOfType Int
+            [PSInstance]::Create(42) | Should -Be 0
+        }
+
+        it 'Char' {
+            [PSInstance]::Create([Char]'a') | Should -BeOfType Char
+            [PSInstance]::Create([Char]'a') | Should -Be ''
+        }
+
+        it 'DateTime' {
+            [PSInstance]::Create((Get-Date))               | Should -BeOfType DateTime
+            [PSInstance]::Create((Get-Date)).ToString('s') | Should -Be '0001-01-01T00:00:00'
+        }
+
+        it 'ScriptBlock' {
+            [PSInstance]::Create({}) | Should -BeOfType ScriptBlock
+        }
+
+        it 'Array' {
+            [PSInstance]::Create(@())     | Should -BeOfType Array
+            [PSInstance]::Create(@(1))    | Should -BeOfType Array
+            [PSInstance]::Create(@(1, 2)) | Should -BeOfType Array
+            [PSInstance]::Create(@(1, 2)) | Should -BeNullOrEmpty
+        }
+
+        it 'HashTable' {
+            [PSInstance]::Create(@{})                     | Should -BeOfType HashTable
+            [PSInstance]::Create(@{ a = 1 })              | Should -BeOfType HashTable
+            [PSInstance]::Create(@{ a = 1 ;b = 2 })       | Should -BeOfType HashTable
+            [PSInstance]::Create(@{ a = 1 ;b = 2 }).Count | Should -Be 0
+        }
+
+        it 'List[Object]' {
+            ,[PSInstance]::Create([Collections.Generic.List[Object]]@())       | Should -BeOfType Collections.Generic.List[Object]
+            ,[PSInstance]::Create([Collections.Generic.List[Object]]@('a'))    | Should -BeOfType Collections.Generic.List[Object]
+            ,[PSInstance]::Create([Collections.Generic.List[Object]]@('a', 1)) | Should -BeOfType Collections.Generic.List[Object]
+            ,[PSInstance]::Create([Collections.Generic.List[Object]]@('a', 1)) | Should -BeNullOrEmpty
+        }
+
+        it 'List[String]' {
+            ,[PSInstance]::Create([Collections.Generic.List[String]]@())       | Should -BeOfType Collections.Generic.List[String]
+            ,[PSInstance]::Create([Collections.Generic.List[String]]@('a'))    | Should -BeOfType Collections.Generic.List[String]
+            ,[PSInstance]::Create([Collections.Generic.List[String]]@('a', 1)) | Should -BeOfType Collections.Generic.List[String]
+            ,[PSInstance]::Create([Collections.Generic.List[String]]@('a', 1)) | Should -BeNullOrEmpty
+        }
+
+        it 'Dictionary[String,String]' {
+            $Dictionary = [Collections.Generic.Dictionary[String,String]]::new()
+            [PSInstance]::Create($Dictionary)       | Should -BeOfType 'Collections.Generic.Dictionary[String,String]'
+            $Dictionary.Add('a', 1)
+            [PSInstance]::Create($Dictionary)       | Should -BeOfType 'Collections.Generic.Dictionary[String,String]'
+            [PSInstance]::Create($Dictionary).Count | Should -Be 0
+        }
+
+        it 'Dictionary[String,Object]' {
+            $Dictionary = [Collections.Generic.Dictionary[String,Object]]::new()
+            [PSInstance]::Create($Dictionary)       | Should -BeOfType 'Collections.Generic.Dictionary[String,Object]'
+            $Dictionary.Add('a', 1)
+            [PSInstance]::Create($Dictionary)       | Should -BeOfType 'Collections.Generic.Dictionary[String,Object]'
+            [PSInstance]::Create($Dictionary).Count | Should -Be 0
+        }
+
+        it 'Ordered' {
+            [PSInstance]::Create([Ordered]@{})                     | Should -BeOfType Collections.Specialized.OrderedDictionary
+            [PSInstance]::Create([Ordered]@{ a = 1; b = 2 })       | Should -BeOfType Collections.Specialized.OrderedDictionary
+            [PSInstance]::Create([Ordered]@{ a = 1; b = 2 }).Count | Should -Be 0
+        }
+
+        it 'PSCustomObject' {
+            [PSInstance]::Create([PSCustomObject]@{})                                   | Should -BeOfType Management.Automation.PSCustomObject
+            [PSInstance]::Create([PSCustomObject]@{ a = 1; b = 2 })                     | Should -BeOfType Management.Automation.PSCustomObject
+            [PSInstance]::Create([PSCustomObject]@{ a = 1; b = 2 }).PSObject.Properties | Should -BeNullOrEmpty
+        }
+
+    }
+}

--- a/Tests/Sort-ObjectGraph.Tests.ps1
+++ b/Tests/Sort-ObjectGraph.Tests.ps1
@@ -42,9 +42,9 @@ Describe 'Sort-ObjectGraph' {
     Context 'Dictionary' {
         $Dictionary = @{ c = 1; a = 3; b = 2 }
         $Sorted = $Dictionary | Sort-ObjectGraph
-        $Sorted | Should -BeOfType PSCustomObject
-        $Sorted.PSObject.Properties.Name  | Should -be 'a', 'b', 'c'
-        $Sorted.PSObject.Properties.Value | Should -be 3, 2, 1
+        $Sorted | Should -BeOfType 'System.Collections.Specialized.OrderedDictionary'
+        $Sorted.Keys   | Should -be 'a', 'b', 'c'
+        $Sorted.Values | Should -be 3, 2, 1
     }
 
     Context 'PSCustomObject' {
@@ -83,29 +83,29 @@ Describe 'Sort-ObjectGraph' {
         It 'Basic Sort' {
             $Sorted = $Object | Sort-ObjectGraph
             $Sorted.Data.Index | Should -Be 1, 2, 3
-            $Sorted.PSObject.Properties.Name | Should -Be 'Comment', 'Data'
-            $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Comment', 'Index', 'Name'
+            $Sorted.Keys | Should -Be 'Comment', 'Data'
+            $Sorted.Data[0].Keys | Should -Be 'Comment', 'Index', 'Name'
         }
 
         It 'Descending' {
             $Sorted = $Object | Sort-ObjectGraph -Descending
             $Sorted.Data.Index | Should -Be 2, 3, 1
-            $Sorted.PSObject.Properties.Name | Should -Be 'Data', 'Comment'
-            $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Name', 'Index', 'Comment'
+            $Sorted.Keys | Should -Be 'Data', 'Comment'
+            $Sorted.Data[0].Keys | Should -Be 'Name', 'Index', 'Comment'
         }
 
         It 'By Name' {
             $Sorted = $Object | Sort-ObjectGraph -By Name
             $Sorted.Data.Index | Should -Be 1, 3, 2
-            $Sorted.PSObject.Properties.Name | Should -Be 'Comment', 'Data'
-            $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Name', 'Comment', 'Index'
+            $Sorted.Keys | Should -Be 'Comment', 'Data'
+            $Sorted.Data[0].Keys | Should -Be 'Name', 'Comment', 'Index'
         }
 
         It 'By Name Descending' {
             $Sorted = $Object | Sort-ObjectGraph -By Name -Descending
             $Sorted.Data.Index | Should -Be 2, 3, 1
-            $Sorted.PSObject.Properties.Name | Should -Be 'Data', 'Comment'
-            $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Name', 'Index', 'Comment'
+            $Sorted.Keys | Should -Be 'Data', 'Comment'
+            $Sorted.Data[0].Keys | Should -Be 'Name', 'Index', 'Comment'
         }
     }
 
@@ -137,28 +137,28 @@ Describe 'Sort-ObjectGraph' {
         It 'Basic Sort' {
             $Sorted = $Object | Sort-ObjectGraph
             $Sorted.Data.Index | Should -Be 1, 2, 3
-            $Sorted.PSObject.Properties.Name | Should -Be 'Comment', 'Data'
+            $Sorted.Keys | Should -Be 'Comment', 'Data'
             $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Comment', 'Index', 'Name'
         }
 
         It 'Descending' {
             $Sorted = $Object | Sort-ObjectGraph -Descending
             $Sorted.Data.Index | Should -Be 2, 3, 1
-            $Sorted.PSObject.Properties.Name | Should -Be 'Data', 'Comment'
+            $Sorted.Keys | Should -Be 'Data', 'Comment'
             $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Name', 'Index', 'Comment'
         }
 
         It 'By Name' {
             $Sorted = $Object | Sort-ObjectGraph -By Name
             $Sorted.Data.Index | Should -Be 1, 3, 2
-            $Sorted.PSObject.Properties.Name | Should -Be 'Comment', 'Data'
+            $Sorted.Keys | Should -Be 'Comment', 'Data'
             $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Name', 'Comment', 'Index'
         }
 
         It 'By Name Descending' {
             $Sorted = $Object | Sort-ObjectGraph -By Name -Descending
             $Sorted.Data.Index | Should -Be 2, 3, 1
-            $Sorted.PSObject.Properties.Name | Should -Be 'Data', 'Comment'
+            $Sorted.Keys | Should -Be 'Data', 'Comment'
             $Sorted.Data[0].PSObject.Properties.Name | Should -Be 'Name', 'Index', 'Comment'
         }
     }
@@ -277,6 +277,29 @@ World
                         3 = 'Three'
                     } | Sort-ObjectGraph
                 } | Should -Not -Throw
+            }
+
+            It "#88 Sort-Object doesn't sort numbers correctly" {
+                $Sorted = Sort-ObjectGraph 100, 3, 20
+                $Sorted[0] | Should -be 3
+                $Sorted[1] | Should -be 20
+                $Sorted[2] | Should -be 100
+
+                $Sorted = ,(100, 3, 20) | Sort-ObjectGraph
+                $Sorted[0] | Should -be 3
+                $Sorted[1] | Should -be 20
+                $Sorted[2] | Should -be 100
+
+
+                $Sorted = @{ a = 100, 20, 3 } | Sort-ObjectGraph
+                $Sorted.a[0] | Should -be 3
+                $Sorted.a[1] | Should -be 20
+                $Sorted.a[2] | Should -be 100
+            }
+
+            It '#89 Sort-ObjectGraph adds $Null to empty lists' {
+                $Sorted = Sort-ObjectGraph @{ a = @() }
+                $Sorted.a.get_Count() | Should -be 0
             }
         }
     }

--- a/Tests/Test-ObjectGraph.Tests.tmp
+++ b/Tests/Test-ObjectGraph.Tests.tmp
@@ -1,0 +1,77 @@
+#Requires -Modules @{ModuleName="Pester"; ModuleVersion="5.5.0"}
+
+using module ..\..\ObjectGraphTools
+
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Person',   Justification = 'False positive')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Schema', Justification = 'False positive')]
+param()
+
+Describe 'Test-ObjectGraph' {
+
+    BeforeAll {
+
+        Set-StrictMode -Version Latest
+
+        $Person = [PSCustomObject]@{
+            FirstName = 'John'
+            LastName = 'Smith'
+            IsAlive = $True
+            Birthday = [DateTime]'Monday,  October 7,  1963 10:47:00 PM'
+            Age = 27
+            Address = [PSCustomObject]@{
+                Street = '21 2nd Street'
+                City = 'New York'
+                State = 'NY'
+                PostalCode = '10021-3100'
+            }
+            phoneNumbers =[PSCustomObject] @(
+                @{ Number = '212 555-1234' },
+                @{ Number = '646 555-4567' }
+            )
+            Children = @('Catherine')
+            Spouse = $Null
+        }
+
+        $Schema = @{
+            title = 'Generated schema for Root'
+            type = 'object'
+            Items = @{
+                AllNodes = @{
+                    type = 'array'
+                    items = @{
+                        type = 'object'
+                        properties = @{
+                            NodeName = @{ type = 'string' }
+                            CertificateFile = @{ type = 'string' }
+                        }
+                        required = @(
+                            'NodeName',
+                            'CertificateFile'
+                        )
+                    }
+                }
+                NonNodeData = @{}
+            }
+            required = @(
+                'AllNodes',
+                'NonNodeData'
+            )
+        }
+
+    }
+
+    Context 'Existence Check' {
+
+        It 'Help' {
+            Test-ObjectGraph -? | Out-String -Stream | Should -Contain SYNOPSIS
+        }
+    }
+
+    Context 'Required' {
+        # $Person | Test-ObjectGraph @{
+        #     Required = @{
+        #         FirstName = @{ Type = 'String' }
+        #     }
+        # }
+    }
+}

--- a/Tests/Test.Windows&Core.ps1
+++ b/Tests/Test.Windows&Core.ps1
@@ -1,12 +1,7 @@
-Import-Module $PSScriptRoot\.. -Force
-
 $Expression = {
     Param($TestFolder)
     Write-Host
     Write-Host "Testing with PowerShell version $($PSVersionTable.PSVersion)"
-    # $ProjectFolder = (Get-Item $TestFolder).Parent.Parent.FullName
-    # [Environment]::SetEnvironmentVariable('PSModulePath', ($ProjectFolder, $Env:PSModulePath -Join ';'), 'Process')
-    # Import-Module ObjectGraphTools
     Import-Module $TestFolder\.. -Force
     Invoke-Pester $TestFolder
 }.ToString()

--- a/WhatsNew.md
+++ b/WhatsNew.md
@@ -1,7 +1,42 @@
-## 2024-04-11 0.1.3 (iRon)
+## 2024-07-22 0.2.1 (iRon)
+  - fixes
+    - #87 ConvertTo-Expression: keys with special characters should be quoted
+    - #89 Sort-ObjectGraph adds $Null to empty lists
+    - #92 ConvertTo-Expression -Expand -1 leaves spaces in map
+
+  - Enhancements
+    - #90 Add $PSCulture and $PSUICulture to the restricted language mode cmdlets and classes
+    - #91 ConvertTo-Expression: better handle special type keys
+
+## 2024-05-04 0.2.0 (iRon)
+  - Break changes
+    - ConvertFrom-Expression parameters: `-ArrayAs` --> `-ListAs`, `-HashTableAs` --> `-MapAs`
+    - Compare-ObjectGraph:
+      - split `-MatchOrder` switch in `-IgnoreListOrder` and `-MatchMapOrder`
+
+  - Enhancements
+    - Created PSListNodeComparer and PSMapNodeComparer
+    - Sorting and added <PSNode>.Sort() method
+    - Improved GetHashCode() method
+
+  - Implemented
+    - #82 Phase out static GetPSNodeType method
+    - #83 $ObjectGraph | Get-Node $PSNodePath should work
+    - #84 PSNodePath should implement Equals (PSNodePath or String)
+
+  - Documentation
+    - Updated commented help of several cmdlets
+    - #65 Update ObjectParser.md with respect to PathName deprecation documentation
+
+## 2024-04-27 0.1.5 (iRon)
+  - Fixes
+    - #80 Unknown PSNode type (Import-Module issues)
+
+## 2024-04-20 0.1.4 (iRon)
   - Fixes
     - Copy-ObjectGraph `-ListAs`/`-MapAs` parameter bug
     - #78 Copy-Object -MapAs @{} should not me case sensitive
+
   - Enhancements
     - Added `ConvertFrom-Expression` `-ArrayAs`/`-HashTableAs` parameters
     - Added `Import-ObjectGraph`


### PR DESCRIPTION
## 2024-07-22 0.2.1 (iRon)
  - fixes
    - #87 ConvertTo-Expression: keys with special characters should be quoted
    - #89 Sort-ObjectGraph adds $Null to empty lists
    - #92 ConvertTo-Expression -Expand -1 leaves spaces in map

  - Enhancements
    - #90 Add $PSCulture and $PSUICulture to the restricted language mode cmdlets and classes
    - #91 ConvertTo-Expression: better handle special type keys