### PR TITLE
Implemented #87, #89, #90, #91 and #92

### DIFF
--- a/Docs/Get-Node.md
+++ b/Docs/Get-Node.md
@@ -8,6 +8,7 @@ Get a node
 ```PowerShell
 Get-Node
     -InputObject <Object>
+    [-Unique]
     [-MaxDepth <Int32>]
     [<CommonParameters>]
 ```
@@ -132,6 +133,20 @@ The path might be either:
 ### <a id="-literal">**`-Literal`**</a>
 
 If Literal switch is set, all (map) nodes in the given path are considered literal.
+
+<table>
+<tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Management.Automation.SwitchParameter">SwitchParameter</a></td></tr>
+<tr><td>Mandatory:</td><td>False</td></tr>
+<tr><td>Position:</td><td>Named</td></tr>
+<tr><td>Default value:</td><td></td></tr>
+<tr><td>Accept pipeline input:</td><td>False</td></tr>
+<tr><td>Accept wildcard characters:</td><td>False</td></tr>
+</table>
+
+### <a id="-unique">**`-Unique`**</a>
+
+Specifies that if a subset of the nodes has identical properties and values,
+only a single node of the subset should be selected.
 
 <table>
 <tr><td>Type:</td><td><a href="https://docs.microsoft.com/en-us/dotnet/api/System.Management.Automation.SwitchParameter">SwitchParameter</a></td></tr>

--- a/Docs/SchemaObject.md
+++ b/Docs/SchemaObject.md
@@ -1,0 +1,32 @@
+Each schema definition requires at least one `map` node and a possible additional collection node to hold the child items.
+This means:
+
+* The validation of a **Leaf** node requires a single schema `map` node, e.g.:
+
+```PowerShell
+@{ Type = 'String' }
+```
+
+* The validation of a **list** node requires a single schema `map` node that contains an embedded `list` node named "**items**", e.g.:
+
+```PowerShell
+@{
+    Type = 'Array'
+    Items = @(
+        ...
+    )
+}
+```
+
+* The validation of a **map** node requires a single schema `map` node that contains another embedded `map` node named "**items**", e.g.:
+
+```PowerShell
+@{
+    Type = 'Array'
+    Items = @{
+        ...
+    }
+}
+```
+
+The object-graph schema depth required to describe every node in an given object requires `2 * (maximum object depth) - 1`.

--- a/ObjectGraphTools.psd1
+++ b/ObjectGraphTools.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ObjectGraphTools.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.2.0'
+    ModuleVersion = '0.2.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -70,6 +70,7 @@
         'Get-ChildNode',
         'Get-Node',
         'Merge-ObjectGraph',
+        'Test-ObjectGraph',
         'ConvertTo-SortedObjectGraph'
     )
 

--- a/Source/Public/Get-Node.ps1
+++ b/Source/Public/Get-Node.ps1
@@ -86,6 +86,10 @@ Using NameSpace System.Management.Automation.Language
 .PARAMETER Literal
     If Literal switch is set, all (map) nodes in the given path are considered literal.
 
+.PARAMETER Unique
+    Specifies that if a subset of the nodes has identical properties and values,
+    only a single node of the subset should be selected.
+
 .PARAMETER MaxDepth
     Specifies the maximum depth that an object graph might be recursively iterated before it throws an error.
     The failsafe will prevent infinitive loops for circular references as e.g. in:
@@ -117,11 +121,19 @@ function Get-Node {
         [Switch]
         $Literal,
 
+        [switch]
+        $Unique,
+
         [Int]
         $MaxDepth
     )
 
     begin {
+        if ($Unique) {
+            # As we want to support case sensitive and insensitive nodes the unique nodes are matched by case
+            # also knowing that in most cases nodes are compared with its self.
+            $UniqueNodes = [System.Collections.Generic.Dictionary[String, System.Collections.Generic.HashSet[Object]]]::new()
+        }
         $XdnPaths = @($Path).ForEach{
             if ($_ -is [XdnPath]) { $_ }
             elseif ($literal) { [XdnPath]::new($_, $True) }
@@ -134,7 +146,13 @@ function Get-Node {
         $Node =
             if ($XdnPaths) { $XdnPaths.ForEach{ $Root.GetNode($_) } }
             else { $Root }
-        if ($ValueOnly) { $Node.Value } else { $Node }
+        if (-not $Unique -or $(
+            $PathName = $Node.Path.ToString()
+            if (-not $UniqueNodes.ContainsKey($PathName)) {
+                $UniqueNodes[$PathName] = [System.Collections.Generic.HashSet[Object]]::new()
+            }
+            $UniqueNodes[$PathName].Add($Node.Value)
+        ))  { $Node }
     }
 }
 

--- a/Source/Public/New-Schema.ps1
+++ b/Source/Public/New-Schema.ps1
@@ -1,0 +1,27 @@
+function New-Schema {
+    [CmdletBinding(HelpUri='https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/New-Schema.md')][OutputType([String])] param(
+
+        [Parameter(Mandatory = $true, ValueFromPipeLine = $True)]
+        $InputObject
+    )
+
+    begin {
+        function GetSchema([PSNode]$Node, $Parent) {
+            # if ($PSVersionTable.PSVersion.Major -eq 5) {
+            #     try { [void][Newtonsoft.Json.JsonConverter] }
+            #     catch { Add-Type -Path "$PSScriptRoot/Assembly/Newtonsoft.Json.dll" }
+            # }
+        }
+    }
+
+    process {
+        # $Schema = @{}
+        # $Node = [PSNode]::parse($InputObject)
+        # GetSchema $Node
+        [Newtonsoft.Json.Schema]::Create()
+        [Newtonsoft.Json.Schema.JsonSchema]::JsonSchema()
+        [Microsoft.AnalysisServices.Tabular]::new()
+    }
+
+}
+

--- a/Source/Public/Sort-ObjectGraph.ps1
+++ b/Source/Public/Sort-ObjectGraph.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Sort object graph
+    Sort an object graph
 
 .DESCRIPTION
     Recursively sorts a object graph.
@@ -69,7 +69,7 @@ function ConvertTo-SortedObjectGraph {
             }
             if ($Node -is [PSListNode]) {
                 $NodeList.Sort($PSListNodeComparer)
-                $Node.Value = @($NodeList.Value)
+                if ($NodeList.Count) { $Node.Value = @($NodeList.Value) } else { $Node.Value =  @() }
             }
             else { # if ($Node -is [PSMapNode])
                 $NodeList.Sort($PSMapNodeComparer)

--- a/Source/Public/Test-ObjectGraph.ps1
+++ b/Source/Public/Test-ObjectGraph.ps1
@@ -1,0 +1,196 @@
+<#
+.SYNOPSIS
+    Tests the properties of an object-graph.
+
+.DESCRIPTION
+    Tests an object-graph against a schema object by verifying that the properties of the object-graph
+    meet the constrains defined in the schema object.
+#>
+
+# JsonSchema Properties
+# Schema properties: [Newtonsoft.Json.Schema.JsonSchema]::New() | Get-Member
+# https://www.newtonsoft.com/json/help/html/Properties_T_Newtonsoft_Json_Schema_JsonSchema.htm
+# Enum PSSchemaName {
+#     Title
+#     Type
+#     PrimaryKey # Should be red before items
+#     Items
+# }
+function Test-ObjectGraph {
+    [CmdletBinding(HelpUri='https://github.com/iRon7/ObjectGraphTools/blob/main/Docs/Test-ObjectGraph.md')][OutputType([String])] param(
+
+        [Parameter(Mandatory = $true, ValueFromPipeLine = $True)]
+        $InputObject,
+
+        [Parameter(Mandatory = $true, Position = 0)]
+        $SchemaObject,
+
+        [Switch]$IsValid,
+
+        [Switch]$ShowAll,
+
+        [Alias('Depth')][int]$MaxDepth = [PSNode]::DefaultMaxDepth
+    )
+
+
+
+    begin {
+
+
+        #  $NodeTypeCache = [System.Collections.Generic.Dictionary[String,NodeType]]::new()
+
+        # $DefinitionOrder = @('Title', 'Type')
+
+        function TestObject([PSNode]$ObjectNode, [PSMapNode]$SchemaNode, [Switch]$IsValid) {
+            $Verbose = $VerbosePreference -in 'Stop', 'Continue', 'Inquire'
+            if ($Verbose) { Write-Verbose $ObjectNode.Path }
+            if (-not $IsValid) { $Violations = [Collections.Generic.List[Object]]::new() }
+            $DefinitionNodes = @{}
+            foreach ($ChildNode in $SchemaNode.ChildNodes) { $DefinitionNodes[$ChildNode.Name] = $ChildNode }
+            foreach ($Name in @('Title', 'Type', 'List', 'Required', 'Optional')) {
+                if (-not $DefinitionNodes.Contains($Name)) { continue }
+                $DefinitionNode = $DefinitionNodes[$Name]
+                $Definition = $DefinitionNode.Value
+                if ($Verbose) { Write-Verbose "    Testing: $Name = $Definition" }
+                $Expected, $Actual = $Null # Setting the $Actual will break the iteration
+                $Checked = [Collections.Generic.HashSet[int]]::new()
+                switch ($DefinitionNode.Name) {
+                    Type {
+                        $Type = $Definition -as [Type]
+                        if (-not $Type) {
+                            Throw "Schema error at $($SchemaNode.Path).Type: Unknown type [$Definition] in schema definition"
+                        }
+                        $Invalid = $ObjectNode.Value -isnot $Type
+                        if ($IsValid -and $Invalid) { return $false }
+                        if ($ShowAll -or $Invalid) { $Expected = "[$Definition] type" }
+                        if ($Invalid) { $Actual = "$($ObjectNode.Value) of type [$($ObjectNode.ValueType)]" }
+                    }
+                    { $_ -in 'List', 'Required', 'Optional' } {
+                        $Invalid = ($ObjectNode.NodeStructure -ne $DefinitionNode.NodeStructure)
+                        if ($IsValid -and $Invalid) { return $false }
+                        if ($ShowAll -or $Invalid) { $Expected = "$($DefinitionNode.NodeStructure) structure" }
+                        if ($Invalid) { $Actual = "$($ObjectNode.Value) with $($ObjectNode.NodeStructure) structure" }
+                    }
+                    List {
+                        if ($ObjectNode -isnot [PSCollectionNode]) { continue } # $ObjectNode and $DefinitionNode are already tested equal structures
+                        if ($Definition -is [HashTable]) {
+                            Throw "Schema error at $($SchemaNode.Path).List: Testing a map list requires an ordered dictionary or PSCustomObject."
+                        }
+                        if ($ObjectNode.Value -is [HashTable]) {
+                            $Expected = "an ordered dictionary or PSCustomObject"
+                            $Actual = "'$($ObjectNode.Type)'"
+                            break
+                        }
+                        $Index = 0
+                        $DefinitionNodes = $DefinitionNode.ChildNodes
+                        foreach ($ChildNode in $ObjectNode.ChildNodes) {
+                            $DefinitionNode = $DefinitionNodes[$Index++]
+                            $Invalid = $ObjectNode -is [PSMapNode] -and $ObjectNode.Name -ne $DefinitionNode.Name
+                            if ($IsValid -and $Invalid) { return $false }
+                            if ($ShowAll -or $Invalid) { $Expected = "node #$Index named '$($DefinitionNode.Name)'" }
+                            if ($Invalid) { $Actual = "'$($ObjectNode.Name)'" }
+                            else {
+                                $TestObject = TestObject $ChildNode $DefinitionNode $IsValid
+                                if ($null -ne $TestObject) { $null = $Checked.add($Index) }
+                                else { if ($IsValid) { Return $false } else { $Violations.AddRange($TestObject) } }
+                            }
+                        }
+                    }
+                    Required {
+                        if ($ObjectNode -is [PSListNode]) { # $ObjectNode and $DefinitionNode are already tested equal structures
+                            foreach ($RequiredNode in $DefinitionNode.ChildNodes) {
+                                $Index = 0
+                                $TestObject = $null
+                                foreach ($ChildNode in $ObjectNode.ChildNodes) {
+                                    if ($ChildNode -notin $Checked) {
+                                        $TestObject = TestObject $ChildNode $RequiredNode -IsValid
+                                        if ($TestObject) { $null = $Checked.add($Index) }
+                                    }
+                                    $Index++
+                                }
+                                $Invalid = $null -eq $TestObject
+                                if ($IsValid -and $Invalid) { return $false }
+                                if ($ShowAll -or $Invalid) { $Expected = $($RequiredNode.Value) }
+                                if ($Invalid) { $Actual = "$($RequiredNode.Name) = $($RequiredNode.Value) doesn't exist" }
+                            }
+                        }
+                        elseif ($ObjectNode -is [PSMapNode]) {
+                            $Index = 0
+                            foreach ($RequiredNode in $DefinitionNode.ChildNodes) {
+                                $KeyExists = $ObjectNode.Contains($RequiredNode.Name)
+                                if ($KeyExists) {
+                                    $null = $Checked.add($Index)
+                                    $ChildNode = $ObjectNode.GetChildNode($RequiredNode.Name)
+                                    $TestObject = TestObject $ChildNode $RequiredNode $IsValid
+                                    if ($null -ne $TestObject) { if ($IsValid) { Return $false } else { $Violations.AddRange(@($TestObject)) } }
+                                }
+                                $Invalid = -Not $KeyExists
+                                if ($IsValid -and $Invalid) { return $false }
+                                if ($ShowAll -or $Invalid) { $Expected = "containing '$($RequiredNode.Name)'" }
+                                if ($Invalid) { $Actual = "'$($RequiredNode.Name)' doesn't exist" }
+                                $Index++
+                            }
+                        }
+                    }
+                    Optional {
+                        if ($ObjectNode -is [PSListNode]) { # $ObjectNode and $DefinitionNode are already tested equal structures
+                            foreach ($OptionalNode in $DefinitionNode.ChildNodes) {
+                                $Index = 0
+                                foreach ($ChildNode in $ObjectNode.ChildNodes) {
+                                    if ($ChildNode -notin $Checked) {
+                                        $TestObject = TestObject $ChildNode $OptionalNode -IsValid
+                                        if ($TestObject) { $Checked.add($Index) }
+                                    }
+                                    $Index++
+                                }
+                            }
+                        }
+                        elseif ($ObjectNode -is [PSMapNode]) {
+                            $Index = 0
+                            foreach ($OptionalNode in $DefinitionNode.ChildNodes) {
+                                if ($ObjectNode.Contains($OptionalNode.Name)) {
+                                    $null = $Checked.add($Index)
+                                    $ChildNode = $ObjectNode.GetChildNode($RequiredNode.Name)
+                                    $TestObject = TestObject $ChildNode $OptionalNode $IsValid
+                                    if ($null -ne $TestObject) { if ($IsValid) { Return $false } else { $Violations.AddRange(@($TestObject)) } }
+                                }
+                                $Index++
+                            }
+                        }
+                        $Invalid = $Checked.Count -lt $ObjectNode.Count
+                        if ($IsValid -and $Invalid) { return $false }
+                        if ($ShowAll -or $Invalid) { $Expected = "optional node" }
+                        if ($Invalid) {
+                            $Index = 0
+                            $RedundantNames = foreach ($Node in $ObjectNode.ChildNodes) {
+                                if ($Index++ -in $Checked) { continue }
+                                $Node.Name
+                            } -Join ', '
+                            $Actual = "the following nodes are not optional: $RedundantNames"
+                        }
+                    }
+                }
+                if ($Expected) {
+                    Write-Host 123
+                    $Violations.Add(
+                        [PSCustomObject]@{
+                            Path     = $ObjectNode.Path
+                            Value    = "$($ObjectNode.Value)"
+                            Expected = $Expected
+                            Actual   = $Actual
+                        }
+                    )
+                    return $Violations
+                }
+            }
+            if ($Violations) { $Violations }
+        }
+
+        $SchemaNode = [PSNode]::ParseInput($SchemaObject)
+    }
+
+    process {
+        $ObjectNode = [PSNode]::ParseInput($InputObject, $MaxDepth)
+        TestObject $ObjectNode $SchemaNode $IsValid
+    }
+}

--- a/Tests/ConvertFrom-Expression.Test.ps1
+++ b/Tests/ConvertFrom-Expression.Test.ps1
@@ -78,4 +78,12 @@ Describe 'ConvertFrom-Expression' {
 '@
         }
     }
+
+    Context 'Issues' {
+
+        It '#90 Add $PSCulture and $PSUICulture to the restricted language mode cmdlets and classes' {
+            '@{ Culture = $PSCulture }'   | ConvertFrom-Expression | ConvertTo-Expression | Should -be "@{ Culture = '$PSCulture' }"
+            '@{ Culture = $PSUICulture }' | ConvertFrom-Expression | ConvertTo-Expression | Should -be "@{ Culture = '$PSUICulture' }"
+        }
+    }
 }

--- a/Tests/ConvertTo-Expression.Tests.ps1
+++ b/Tests/ConvertTo-Expression.Tests.ps1
@@ -625,7 +625,7 @@ Describe 'ConvertTo-Expression' {
         }
 
         It 'ConvertTo-Expression (Default)' {
-            $Expression = ConvertTo-Expression -InputObject $Object
+            $Expression = ConvertTo-Expression -InputObject $Object 
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
 @{
@@ -778,14 +778,14 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{number='212 555-1234' }, @{number='646 555-4567' });children=@('Catherine');spouse=$Null }
+@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandSingleton -ExpandDepth -1' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandSingleton -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234' }, @{ number='646 555-4567' });children=@('Catherine');spouse=$Null }
+@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Constrained' {
@@ -1092,28 +1092,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Constrained -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{number='212 555-1234' }, @{number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[PSCustomObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{number='212 555-1234' }, @{number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234' }, @{ number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[PSCustomObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[PSCustomObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{ street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100' };phone_numbers=@(@{ number='212 555-1234' }, @{ number='646 555-4567' });children=@('Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name='John';last_name='Smith';is_alive=$True;age=27;address=[System.Management.Automation.PSObject]@{street_address='21 2nd Street';city='New York';state='NY';postal_code='10021-3100'};phone_numbers=@(@{number='212 555-1234'}, @{number='646 555-4567'});children=@('Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Constrained -Explicit' {
@@ -1420,28 +1420,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234' }, [hashtable]@{number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234' }, [hashtable]@{ number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Constrained -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Full' {
@@ -1748,28 +1748,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -LanguageMode Full -ExpandDepth -1
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234' }, [hashtable]@{number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234' }, [hashtable]@{ number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -FullTypeName' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -FullTypeName
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -LanguageMode Full -Explicit' {
@@ -2076,28 +2076,28 @@ Describe 'ConvertTo-Expression' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234' }, [hashtable]@{number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Full -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Full -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[PSCustomObject]@{ first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{ street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100' };phone_numbers=[array]@([hashtable]@{ number=[string]'212 555-1234' }, [hashtable]@{ number=[string]'646 555-4567' });children=[array]@([string]'Catherine');spouse=$Null }
+[PSCustomObject]@{first_name=[string]'John';last_name=[string]'Smith';is_alive=[bool]$True;age=[int]27;address=[PSCustomObject]@{street_address=[string]'21 2nd Street';city=[string]'New York';state=[string]'NY';postal_code=[string]'10021-3100'};phone_numbers=[array]@([hashtable]@{number=[string]'212 555-1234'}, [hashtable]@{number=[string]'646 555-4567'});children=[array]@([string]'Catherine');spouse=$Null}
 '@
         }
         It 'ConvertTo-Expression -FullTypeName -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit' {
             $Expression = ConvertTo-Expression -InputObject $Object -FullTypeName -ExpandDepth -1 -LanguageMode Full -ExpandSingleton -Explicit
             { Invoke-Expression $Expression } | Should -not -Throw
             $Expression | Should -Be @'
-[System.Management.Automation.PSObject]@{ first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{ street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100' };phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{ number=[System.String]'212 555-1234' }, [System.Collections.Hashtable]@{ number=[System.String]'646 555-4567' });children=[System.Object[]]@([System.String]'Catherine');spouse=$Null }
+[System.Management.Automation.PSObject]@{first_name=[System.String]'John';last_name=[System.String]'Smith';is_alive=[System.Boolean]$True;age=[System.Int32]27;address=[System.Management.Automation.PSObject]@{street_address=[System.String]'21 2nd Street';city=[System.String]'New York';state=[System.String]'NY';postal_code=[System.String]'10021-3100'};phone_numbers=[System.Object[]]@([System.Collections.Hashtable]@{number=[System.String]'212 555-1234'}, [System.Collections.Hashtable]@{number=[System.String]'646 555-4567'});children=[System.Object[]]@([System.String]'Catherine');spouse=$Null}
 '@
         }
     }
@@ -2106,6 +2106,23 @@ Describe 'ConvertTo-Expression' {
 
         It '#59 quoting bug' {
             @{ Test = "foo'bar" } | ConvertTo-Expression | Should -Be "@{ Test = 'foo''bar' }"
+        }
+
+        It '#87 ConvertTo-Expression: keys with special characters should be quoted' { # https://stackoverflow.com/questions/62754771/unquoted-key-rules-and-best-practices
+            @{ a = 1 }     | ConvertTo-Expression | Should -Be '@{ a = 1 }'
+            @{ '$a'  = 1 } | ConvertTo-Expression | Should -Be '@{ ''$a'' = 1 }' # --> @{ '$a' = 1 }
+            @{ 'a b' = 1 } | ConvertTo-Expression | Should -Be "@{ 'a b' = 1 }"
+            @{ 'a"b' = 1 } | ConvertTo-Expression | Should -Be "@{ 'a""b' = 1 }" # --> @{ 'a"b' = 1 }
+            @{ "a'b" = 1 } | ConvertTo-Expression | Should -Be "@{ 'a''b' = 1 }"
+        }
+
+        It '#92 ConvertTo-Expression -Expand -1 leaves space after map value' {
+            @{ a = 1 } | ConvertTo-Expression -ExpandDepth -1 | Should -Be '@{a=1}'
+        }
+
+        It '#91 ConvertTo-Expression: better handle special type keys' {
+            @{ (Get-Date 1963-10-07) = 7 } | ConvertTo-Expression      | Should -Be "@{ '1963-10-07T00:00:00.0000000' = 7 }"
+            @{ @{ a = 1 } = 'Test' } | ConvertTo-Expression -Expand -1 | Should -Be "@{@{a=1}='Test'}"
         }
     }
 }

--- a/Tests/Get-Node.Tests.ps1
+++ b/Tests/Get-Node.Tests.ps1
@@ -2,8 +2,9 @@
 
 using module ..\..\ObjectGraphTools
 
-[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Object', Justification = 'False positive')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Object',      Justification = 'False positive')]
 [Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'ObjectGraph', Justification = 'False positive')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Nodes',       Justification = 'False positive')]
 param()
 
 Describe 'Get-Node' {
@@ -135,6 +136,21 @@ Describe 'Get-Node' {
             $Title.Value | Should -Be 'Learning PowerShell'
         }
 
+    }
+
+    Context 'Unique' {
+
+        BeforeAll {
+            $Nodes = ($Object | Get-Node 'data.name=*o*') + ($Object | Get-Node 'data.name=*t*')
+        }
+
+        it 'Concatenated nodes' {
+            ($Nodes | Get-Node).Count | Should -be 4
+        }
+
+        it 'Merged nodes' {
+            ($Nodes | Get-Node -Unique).Count | Should -be 3
+        }
     }
 
     Context 'Change value' {

--- a/Tests/Sort-ObjectGraph.Tests.ps1
+++ b/Tests/Sort-ObjectGraph.Tests.ps1
@@ -278,6 +278,29 @@ World
                     } | Sort-ObjectGraph
                 } | Should -Not -Throw
             }
+
+            It "#88 Sort-Object doesn't sort numbers correctly" {
+                $Sorted = Sort-ObjectGraph 100, 3, 20
+                $Sorted[0] | Should -be 3
+                $Sorted[1] | Should -be 20
+                $Sorted[2] | Should -be 100
+
+                $Sorted = ,(100, 3, 20) | Sort-ObjectGraph
+                $Sorted[0] | Should -be 3
+                $Sorted[1] | Should -be 20
+                $Sorted[2] | Should -be 100
+
+
+                $Sorted = @{ a = 100, 20, 3 } | Sort-ObjectGraph
+                $Sorted.a[0] | Should -be 3
+                $Sorted.a[1] | Should -be 20
+                $Sorted.a[2] | Should -be 100
+            }
+
+            It '#89 Sort-ObjectGraph adds $Null to empty lists' {
+                $Sorted = Sort-ObjectGraph @{ a = @() }
+                $Sorted.a.get_Count() | Should -be 0
+            }
         }
     }
 }

--- a/Tests/Test-ObjectGraph.Tests.tmp
+++ b/Tests/Test-ObjectGraph.Tests.tmp
@@ -1,0 +1,77 @@
+#Requires -Modules @{ModuleName="Pester"; ModuleVersion="5.5.0"}
+
+using module ..\..\ObjectGraphTools
+
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Person',   Justification = 'False positive')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', 'Schema', Justification = 'False positive')]
+param()
+
+Describe 'Test-ObjectGraph' {
+
+    BeforeAll {
+
+        Set-StrictMode -Version Latest
+
+        $Person = [PSCustomObject]@{
+            FirstName = 'John'
+            LastName = 'Smith'
+            IsAlive = $True
+            Birthday = [DateTime]'Monday,  October 7,  1963 10:47:00 PM'
+            Age = 27
+            Address = [PSCustomObject]@{
+                Street = '21 2nd Street'
+                City = 'New York'
+                State = 'NY'
+                PostalCode = '10021-3100'
+            }
+            phoneNumbers =[PSCustomObject] @(
+                @{ Number = '212 555-1234' },
+                @{ Number = '646 555-4567' }
+            )
+            Children = @('Catherine')
+            Spouse = $Null
+        }
+
+        $Schema = @{
+            title = 'Generated schema for Root'
+            type = 'object'
+            Items = @{
+                AllNodes = @{
+                    type = 'array'
+                    items = @{
+                        type = 'object'
+                        properties = @{
+                            NodeName = @{ type = 'string' }
+                            CertificateFile = @{ type = 'string' }
+                        }
+                        required = @(
+                            'NodeName',
+                            'CertificateFile'
+                        )
+                    }
+                }
+                NonNodeData = @{}
+            }
+            required = @(
+                'AllNodes',
+                'NonNodeData'
+            )
+        }
+
+    }
+
+    Context 'Existence Check' {
+
+        It 'Help' {
+            Test-ObjectGraph -? | Out-String -Stream | Should -Contain SYNOPSIS
+        }
+    }
+
+    Context 'Required' {
+        # $Person | Test-ObjectGraph @{
+        #     Required = @{
+        #         FirstName = @{ Type = 'String' }
+        #     }
+        # }
+    }
+}

--- a/WhatsNew.md
+++ b/WhatsNew.md
@@ -1,4 +1,14 @@
-## 2024-05-04 0.1.6 (iRon)
+## 2024-07-22 0.2.1 (iRon)
+  - fixes
+    - #87 ConvertTo-Expression: keys with special characters should be quoted
+    - #89 Sort-ObjectGraph adds $Null to empty lists
+    - #92 ConvertTo-Expression -Expand -1 leaves spaces in map
+
+  - Enhancements
+    - #90 Add $PSCulture and $PSUICulture to the restricted language mode cmdlets and classes
+    - #91 ConvertTo-Expression: better handle special type keys
+
+## 2024-05-04 0.2.0 (iRon)
   - Break changes
     - ConvertFrom-Expression parameters: `-ArrayAs` --> `-ListAs`, `-HashTableAs` --> `-MapAs`
     - Compare-ObjectGraph:


### PR DESCRIPTION
## 2024-07-22 0.2.1 (iRon)
  - fixes
    - #87 ConvertTo-Expression: keys with special characters should be quoted
    - #89 Sort-ObjectGraph adds $Null to empty lists
    - #92 ConvertTo-Expression -Expand -1 leaves spaces in map

  - Enhancements
    - #90 Add $PSCulture and $PSUICulture to the restricted language mode cmdlets and classes
    - #91 ConvertTo-Expression: better handle special type keys